### PR TITLE
fix: resolve omp.h not found when openmp not enabled

### DIFF
--- a/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/fp32/topk.h
+++ b/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/fp32/topk.h
@@ -18,7 +18,9 @@
 #ifndef __ST_PPL_KERNEL_X86_FP32_TOPK_H_
 #define __ST_PPL_KERNEL_X86_FP32_TOPK_H_
 
+#ifdef PPL_USE_X86_OMP
 #include <omp.h>
+#endif
 #include "ppl/kernel/x86/common/general_include.h"
 
 namespace ppl { namespace kernel { namespace x86 {


### PR DESCRIPTION
Hi, PPL Team

This PR fix a compile error "omp.h not found" when build with `./build.sh -DHPCC_USE_CUDA=OFF`.

The compile environment is:
- OS: ubuntu 20.04
- C++ compiler: `CXX=clang`,  clang++ version is 13.0.0