### PR TITLE
Tzc/x86 add concat split more data type support and fix nms resize bug

### DIFF
--- a/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/bool/concat.h
+++ b/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/bool/concat.h
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_BOOL_CONCAT_H_
+#define __ST_PPL_KERNEL_X86_BOOL_CONCAT_H_
+
+#include "ppl/kernel/x86/common/general_include.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+ppl::common::RetCode concat_n16cx_bool(
+    const ppl::nn::TensorShape **src_shape_list,
+    const uint8_t **src_list,
+    const int32_t num_src,
+    const int32_t axis,
+    uint8_t *dst);
+
+ppl::common::RetCode concat_ndarray_bool(
+    const ppl::nn::TensorShape **src_shape_list,
+    const uint8_t **src_list,
+    const int32_t num_src,
+    const int32_t axis,
+    uint8_t *dst);
+
+}}}; // namespace ppl::kernel::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/bool/split.h
+++ b/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/bool/split.h
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_BOOL_SPLIT_H_
+#define __ST_PPL_KERNEL_X86_BOOL_SPLIT_H_
+
+#include "ppl/kernel/x86/common/general_include.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+ppl::common::RetCode split_ndarray_bool(
+    const ppl::nn::TensorShape *src_shape,
+    const ppl::nn::TensorShape **dst_shape_list,
+    const uint8_t *src,
+    const int32_t slice_axis,
+    const int32_t num_dst,
+    uint8_t **dst_list);
+
+ppl::common::RetCode split_n16cx_bool(
+    const ppl::nn::TensorShape *src_shape,
+    const ppl::nn::TensorShape **dst_shape_list,
+    const uint8_t *src,
+    const int32_t slice_axis,
+    const int32_t num_dst,
+    uint8_t **dst_list);
+
+}}}; // namespace ppl::kernel::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/int64/split.h
+++ b/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/int64/split.h
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_INT64_SPLIT_H_
+#define __ST_PPL_KERNEL_X86_INT64_SPLIT_H_
+
+#include "ppl/kernel/x86/common/general_include.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+ppl::common::RetCode split_ndarray_int64(
+    const ppl::nn::TensorShape *src_shape,
+    const ppl::nn::TensorShape **dst_shape_list,
+    const int64_t *src,
+    const int32_t slice_axis,
+    const int32_t num_dst,
+    int64_t **dst_list);
+
+ppl::common::RetCode split_n16cx_int64(
+    const ppl::nn::TensorShape *src_shape,
+    const ppl::nn::TensorShape **dst_shape_list,
+    const int64_t *src,
+    const int32_t slice_axis,
+    const int32_t num_dst,
+    int64_t **dst_list);
+
+}}}; // namespace ppl::kernel::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/bool/concat/concat_n16cx_bool.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/bool/concat/concat_n16cx_bool.cpp
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/kernel/x86/common/internal_include.h"
+#include "ppl/kernel/x86/common/concat/concat_common.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+ppl::common::RetCode concat_n16cx_bool(
+    const ppl::nn::TensorShape **src_shape_list,
+    const uint8_t **src_list,
+    const int32_t num_src,
+    const int32_t axis,
+    uint8_t *dst)
+{
+    return concat_n16cx<uint8_t>(src_shape_list, src_list, num_src, axis, dst);
+}
+
+}}}; // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/bool/concat/concat_ndarray_bool.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/bool/concat/concat_ndarray_bool.cpp
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/kernel/x86/common/internal_include.h"
+#include "ppl/kernel/x86/common/concat/concat_common.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+ppl::common::RetCode concat_ndarray_bool(
+    const ppl::nn::TensorShape **src_shape_list,
+    const uint8_t **src_list,
+    const int32_t num_src,
+    const int32_t axis,
+    uint8_t *dst)
+{
+    return concat_ndarray<uint8_t>(src_shape_list, src_list, num_src, axis, dst);
+}
+
+}}}; // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/bool/split/split_n16cx_bool.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/bool/split/split_n16cx_bool.cpp
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/kernel/x86/common/internal_include.h"
+#include "ppl/kernel/x86/common/split/split_common.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+ppl::common::RetCode split_n16cx_bool(
+    const ppl::nn::TensorShape *src_shape,
+    const ppl::nn::TensorShape **dst_shape_list,
+    const uint8_t *src,
+    const int32_t slice_axis,
+    const int32_t num_dst,
+    uint8_t **dst_list)
+{
+    return split_n16cx<uint8_t>(src_shape, dst_shape_list, src, slice_axis, num_dst, dst_list);
+}
+
+}}} // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/bool/split/split_ndarray_bool.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/bool/split/split_ndarray_bool.cpp
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/kernel/x86/common/internal_include.h"
+#include "ppl/kernel/x86/common/split/split_common.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+ppl::common::RetCode split_ndarray_bool(
+    const ppl::nn::TensorShape *src_shape,
+    const ppl::nn::TensorShape **dst_shape_list,
+    const uint8_t *src,
+    const int32_t slice_axis,
+    const int32_t num_dst,
+    uint8_t **dst_list)
+{
+    return split_ndarray<uint8_t>(src_shape, dst_shape_list, src, slice_axis, num_dst, dst_list);
+}
+
+}}} // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/resize2d/resize2d_fp32.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/resize2d/resize2d_fp32.cpp
@@ -43,7 +43,7 @@ ppl::common::RetCode reisze2d_ndarray_pytorch_linear_floor_fp32(
         const float *l_src = src + ni * src_h * src_w;
         float *l_dst       = dst + ni * dst_h * dst_w;
         for (int64_t oh = 0; oh < dst_h; ++oh) {
-            float ih = (oh + 0.5f) * hscale - 0.5f;
+            float ih = dst_h > 1 ? (oh + 0.5f) * hscale - 0.5f : 0;
             int64_t h0, h1;
             float h0_lambda, h1_lambda;
             if (ih < 0) {
@@ -59,7 +59,7 @@ ppl::common::RetCode reisze2d_ndarray_pytorch_linear_floor_fp32(
             }
 
             for (int64_t ow = 0; ow < dst_w; ++ow) {
-                float iw = (ow + 0.5f) * wscale - 0.5f;
+                float iw = dst_w > 1 ? (ow + 0.5f) * wscale - 0.5f : 0;
                 int64_t w0, w1;
                 float w0_lambda, w1_lambda;
                 if (iw < 0) {
@@ -135,9 +135,9 @@ ppl::common::RetCode reisze2d_ndarray_asymmetric_nearest_floor_fp32(
 }
 
 inline void calc_resize_cubic_coeff(
-        const float r,
-        const float A,
-        float *coeff)
+    const float r,
+    const float A,
+    float *coeff)
 {
     coeff[0] = ((A * (r + 1) - 5 * A) * (r + 1) + 8 * A) * (r + 1) - 4 * A;
     coeff[1] = ((A + 2) * r - (A + 3)) * r * r + 1;
@@ -147,11 +147,11 @@ inline void calc_resize_cubic_coeff(
 
 template <typename T>
 inline T get_value_bounded(
-        const T *src,
-        const int64_t h,
-        const int64_t w,
-        const int64_t src_h,
-        const int64_t src_w)
+    const T *src,
+    const int64_t h,
+    const int64_t w,
+    const int64_t src_h,
+    const int64_t src_w)
 {
     int64_t h_ = max<int64_t>(min(h, src_h - 1), 0);
     int64_t w_ = max<int64_t>(min(w, src_w - 1), 0);
@@ -181,7 +181,7 @@ ppl::common::RetCode reisze2d_ndarray_pytorch_cubic_floor_fp32(
     std::vector<float> coeff_y_tab(dst_h * 4);
     PRAGMA_OMP_PARALLEL_FOR()
     for (int64_t oh = 0; oh < dst_h; ++oh) {
-        float ih   = (oh + 0.5f) * hscale - 0.5f;
+        float ih   = dst_h > 1 ? (oh + 0.5f) * hscale - 0.5f : 0;
         int64_t sy = ::floor(ih);
         float fy   = ih - sy;
         sy_tab[oh] = sy;
@@ -194,7 +194,7 @@ ppl::common::RetCode reisze2d_ndarray_pytorch_cubic_floor_fp32(
     std::vector<float> coeff_x_tab(dst_w * 4);
     PRAGMA_OMP_PARALLEL_FOR()
     for (int64_t ow = 0; ow < dst_w; ++ow) {
-        float iw   = (ow + 0.5f) * wscale - 0.5f;
+        float iw   = dst_w > 1 ? (ow + 0.5f) * wscale - 0.5f : 0;
         int64_t sx = ::floor(iw);
         float fx   = iw - sx;
         sx_tab[ow] = sx;

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/resize2d/resize2d_fp32_avx.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/resize2d/resize2d_fp32_avx.cpp
@@ -49,7 +49,7 @@ ppl::common::RetCode resize2d_n16chw_pytorch_2linear_floor_fp32_avx(
 
     PRAGMA_OMP_PARALLEL_FOR()
     for (int64_t ow = 0; ow < dst_w; ow++) {
-        float iw = (ow + 0.5f) * wscale - 0.5f;
+        float iw = dst_w > 1 ? (ow + 0.5f) * wscale - 0.5f : 0;
         if (iw < 0) {
             w0_vec[ow]        = 0;
             w1_vec[ow]        = 0;
@@ -68,7 +68,7 @@ ppl::common::RetCode resize2d_n16chw_pytorch_2linear_floor_fp32_avx(
         const float *l_src = src + bc * src_hw;
         float *l_dst       = dst + bc * dst_hw;
         for (int64_t oh = 0; oh < dst_h; ++oh) {
-            float ih = (oh + 0.5f) * hscale - 0.5f;
+            float ih = dst_h > 1 ? (oh + 0.5f) * hscale - 0.5f : 0;
             int64_t h0, h1;
             float h0_lambda, h1_lambda;
             if (ih < 0) {

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/resize2d/resize2d_n16cx_fp32_avx512.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/resize2d/resize2d_n16cx_fp32_avx512.cpp
@@ -51,7 +51,7 @@ ppl::common::RetCode resize2d_n16cx_pytorch_2linear_floor_fp32_avx512(
 
     PRAGMA_OMP_PARALLEL_FOR()
     for (int64_t ow = 0; ow < dst_w; ow++) {
-        float iw = (ow + 0.5f) * wscale - 0.5f;
+        float iw = dst_w > 1 ? (ow + 0.5f) * wscale - 0.5f : 0;
         if (iw < 0) {
             w0_vec[ow]        = 0;
             w1_vec[ow]        = 0;
@@ -71,7 +71,7 @@ ppl::common::RetCode resize2d_n16cx_pytorch_2linear_floor_fp32_avx512(
         float *l_dst       = dst + bc * dst_hw;
 
         for (int64_t oh = 0; oh < dst_h; ++oh) {
-            float ih = (oh + 0.5f) * hscale - 0.5f;
+            float ih = dst_h > 1 ? (oh + 0.5f) * hscale - 0.5f : 0;
             int64_t h0, h1;
             float h0_lambda, h1_lambda;
             if (ih < 0) {

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/int64/split/split_n16cx_int64.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/int64/split/split_n16cx_int64.cpp
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/kernel/x86/common/internal_include.h"
+#include "ppl/kernel/x86/common/split/split_common.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+ppl::common::RetCode split_n16cx_int64(
+    const ppl::nn::TensorShape *src_shape,
+    const ppl::nn::TensorShape **dst_shape_list,
+    const int64_t *src,
+    const int32_t slice_axis,
+    const int32_t num_dst,
+    int64_t **dst_list)
+{
+    return split_n16cx<int64_t>(src_shape, dst_shape_list, src, slice_axis, num_dst, dst_list);
+}
+
+}}} // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/int64/split/split_ndarray_int64.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/int64/split/split_ndarray_int64.cpp
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/kernel/x86/common/internal_include.h"
+#include "ppl/kernel/x86/common/split/split_common.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+ppl::common::RetCode split_ndarray_int64(
+    const ppl::nn::TensorShape *src_shape,
+    const ppl::nn::TensorShape **dst_shape_list,
+    const int64_t *src,
+    const int32_t slice_axis,
+    const int32_t num_dst,
+    int64_t **dst_list)
+{
+    return split_ndarray<int64_t>(src_shape, dst_shape_list, src, slice_axis, num_dst, dst_list);
+}
+
+}}} // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/kernels/mmcv/mmcv_gridsample_kernel.cc
+++ b/src/ppl/nn/engines/x86/kernels/mmcv/mmcv_gridsample_kernel.cc
@@ -42,7 +42,6 @@ ppl::common::RetCode MMCVGridSampleKernel::DoExecute(KernelExecContext* ctx) {
         }
 #ifdef PPL_USE_X86_AVX512
         else if (MayUseISA(ppl::common::ISA_X86_AVX512)) {
-            LOG(ERROR) << "running here";
             return kernel::x86::mmcv_gridsample_linear_ndarray_fp32_avx512(
                 &input->GetShape(), &grid->GetShape(), input->GetBufferPtr<float>(), grid->GetBufferPtr<float>(),
                 param_->align_corners, param_->padding_mode, output->GetBufferPtr<float>());

--- a/src/ppl/nn/engines/x86/kernels/onnx/split_kernel.cc
+++ b/src/ppl/nn/engines/x86/kernels/onnx/split_kernel.cc
@@ -19,13 +19,15 @@
 #include "ppl/nn/engines/x86/macros.h"
 
 #include "ppl/kernel/x86/fp32/split.h"
+#include "ppl/kernel/x86/int64/split.h"
+#include "ppl/kernel/x86/bool/split.h"
 
 namespace ppl { namespace nn { namespace x86 {
 
 ppl::common::RetCode SplitKernel::DoExecute(KernelExecContext* ctx) {
     auto input = ctx->GetInput<TensorImpl>(0);
 
-    std::vector<float*> dst_list(ctx->GetOutputCount());
+    std::vector<void*> dst_list(ctx->GetOutputCount());
     std::vector<const TensorShape*> dst_shape_list(ctx->GetOutputCount());
 
     PPLNN_X86_DEBUG_TRACE("Op: %s\n", GetName().c_str());
@@ -35,7 +37,7 @@ ppl::common::RetCode SplitKernel::DoExecute(KernelExecContext* ctx) {
         auto output = ctx->GetOutput<TensorImpl>(i);
         PPLNN_X86_DEBUG_TRACE("Output [outputs[%u]]:\n", i);
         PPL_X86_TENSOR_PRINT_DEBUG_MSG(output);
-        dst_list[i] = output->GetBufferPtr<float>();
+        dst_list[i] = output->GetBufferPtr<void>();
         dst_shape_list[i] = &output->GetShape();
     }
     PPLNN_X86_DEBUG_TRACE("axis: %d\n", param_->axis);
@@ -46,8 +48,8 @@ ppl::common::RetCode SplitKernel::DoExecute(KernelExecContext* ctx) {
 
     auto data_type = input->GetShape().GetDataType();
     auto data_format = input->GetShape().GetDataFormat();
-    if (data_type == ppl::common::DATATYPE_FLOAT32 && data_format == ppl::common::DATAFORMAT_N16CX && real_axis == 1 &&
-        MayUseISA(ppl::common::ISA_X86_AVX)) {
+    if (ppl::common::GetSizeOfDataType(data_type) == 4 && data_format == ppl::common::DATAFORMAT_N16CX &&
+        real_axis == 1 && MayUseISA(ppl::common::ISA_X86_AVX)) {
         bool interleave_channels = false;
         for (uint32_t i = 0; i < dst_shape_list.size() - 1; i++) {
             if (dst_shape_list[i]->GetDim(1) % 16 != 0) {
@@ -56,13 +58,13 @@ ppl::common::RetCode SplitKernel::DoExecute(KernelExecContext* ctx) {
             }
         }
         if (interleave_channels) {
-            return kernel::x86::split_n16cx_interleave_channels_fp32_avx(&input->GetShape(), dst_shape_list.data(),
-                                                                         input->GetBufferPtr<float>(), real_axis,
-                                                                         ctx->GetOutputCount(), 1, dst_list.data());
+            return kernel::x86::split_n16cx_interleave_channels_fp32_avx(
+                &input->GetShape(), dst_shape_list.data(), input->GetBufferPtr<float>(), real_axis,
+                ctx->GetOutputCount(), 1, (float**)dst_list.data());
         }
     }
 
-    if (data_type == ppl::common::DATATYPE_FLOAT32) {
+    if (ppl::common::GetSizeOfDataType(data_type) == 4) {
         if (data_format == ppl::common::DATAFORMAT_NDARRAY) {
             return kernel::x86::split_ndarray_fp32(&input->GetShape(), dst_shape_list.data(),
                                                    input->GetBufferPtr<float>(), param_->axis, ctx->GetOutputCount(),
@@ -71,6 +73,30 @@ ppl::common::RetCode SplitKernel::DoExecute(KernelExecContext* ctx) {
             return kernel::x86::split_n16cx_fp32(&input->GetShape(), dst_shape_list.data(),
                                                  input->GetBufferPtr<float>(), param_->axis, ctx->GetOutputCount(),
                                                  (float**)dst_list.data());
+        } else {
+            LOG(ERROR) << "unsupported data format: " << ppl::common::GetDataFormatStr(data_format);
+        }
+    } else if (ppl::common::GetSizeOfDataType(data_type) == 8) {
+        if (data_format == ppl::common::DATAFORMAT_NDARRAY) {
+            return kernel::x86::split_ndarray_int64(&input->GetShape(), dst_shape_list.data(),
+                                                    input->GetBufferPtr<int64_t>(), param_->axis, ctx->GetOutputCount(),
+                                                    (int64_t**)dst_list.data());
+        } else if (data_format == ppl::common::DATAFORMAT_N16CX) {
+            return kernel::x86::split_n16cx_int64(&input->GetShape(), dst_shape_list.data(),
+                                                  input->GetBufferPtr<int64_t>(), param_->axis, ctx->GetOutputCount(),
+                                                  (int64_t**)dst_list.data());
+        } else {
+            LOG(ERROR) << "unsupported data format: " << ppl::common::GetDataFormatStr(data_format);
+        }
+    } else if (ppl::common::GetSizeOfDataType(data_type) == 1) {
+        if (data_format == ppl::common::DATAFORMAT_NDARRAY) {
+            return kernel::x86::split_ndarray_bool(&input->GetShape(), dst_shape_list.data(),
+                                                   input->GetBufferPtr<uint8_t>(), param_->axis, ctx->GetOutputCount(),
+                                                   (uint8_t**)dst_list.data());
+        } else if (data_format == ppl::common::DATAFORMAT_N16CX) {
+            return kernel::x86::split_n16cx_bool(&input->GetShape(), dst_shape_list.data(),
+                                                 input->GetBufferPtr<uint8_t>(), param_->axis, ctx->GetOutputCount(),
+                                                 (uint8_t**)dst_list.data());
         } else {
             LOG(ERROR) << "unsupported data format: " << ppl::common::GetDataFormatStr(data_format);
         }

--- a/src/ppl/nn/engines/x86/optimizer/ops/onnx/split_op.cc
+++ b/src/ppl/nn/engines/x86/optimizer/ops/onnx/split_op.cc
@@ -36,10 +36,6 @@ RetCode SplitOp::Init(const OptKernelOptions& options) {
         if (ret != RC_SUCCESS) {
             return ret;
         }
-        if (info->GetInput<TensorImpl>(0)->GetShape().GetDataType() != DATATYPE_FLOAT32) {
-            LOG(ERROR) << "only support fp32 now.";
-            return RC_UNSUPPORTED;
-        }
         return RC_SUCCESS;
     };
 

--- a/src/ppl/nn/oputils/onnx/reshape_non_max_suppression.cc
+++ b/src/ppl/nn/oputils/onnx/reshape_non_max_suppression.cc
@@ -49,8 +49,11 @@ RetCode ReshapeNonMaxSuppression(InputOutputInfo* info, int64_t max_output_boxes
 }
 
 RetCode ReshapeNonMaxSuppression(InputOutputInfo* info) {
-    int64_t max_output_boxes_per_class =
-        info->GetInputCount() >= 3 ? (info->GetInput<TensorImpl>(2)->GetBufferPtr<int64_t>())[0] : 0;
+    int64_t max_output_boxes_per_class = 0;
+    if (info->GetInputCount() >= 3 && info->GetInput<TensorImpl>(2) != nullptr &&
+        info->GetInput<TensorImpl>(2)->GetBufferPtr<int64_t>() != nullptr) {
+        max_output_boxes_per_class = info->GetInput<TensorImpl>(2)->GetBufferPtr<int64_t>()[0];
+    }
     return ReshapeNonMaxSuppression(info, max_output_boxes_per_class);
 }
 


### PR DESCRIPTION
added more data_type support for x86 concat/split op.    
fixed reshape nms bug.  
fixed x86 resize op coordinate compute bug.  