### PR TITLE
Fix: align directive inline assembly on Darwin

### DIFF
--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/common/macros.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/common/macros.h
@@ -22,6 +22,10 @@
 #define PPL_USE_X86_MSVC
 #endif
 
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+#define PPL_USE_X86_DARWIN
+#endif
+
 #if (defined(__x86_64__) && (defined(__GNUC__) || defined(__GNUG__) || defined(__clang__)))
 #ifndef __APPLE_CC__
 #define PPL_USE_X86_INLINE_ASM_MACRO
@@ -69,6 +73,12 @@
 
 #define PPL_X86_TENSOR_MAX_DIMS() 8
 #define PPL_X86_CACHELINE_BYTES() 64
+
+#ifdef PPL_USE_X86_DARWIN
+#define PPL_X86_INLINE_ASM_ALIGN() ".align 4\n"
+#else
+#define PPL_X86_INLINE_ASM_ALIGN() ".align 16\n"
+#endif
 
 #define PPL_STR_INNER(X) #X
 #define PPL_STR(X)       PPL_STR_INNER(X)

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/avx512/conv2d_n16cx_gemm_direct_blk1x14_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/avx512/conv2d_n16cx_gemm_direct_blk1x14_kernel_fp32_avx512.h
@@ -173,7 +173,11 @@ void conv2d_n16cx_gemm_direct_fp32_avx512_blk1x14_kernel_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 6f\n" // label_ic_remain
 "5:\n" // label_ic_body
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
         ".if HW_LEN < 6\n"
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm28\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/avx512/conv2d_n16cx_gemm_direct_blk1x14_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/avx512/conv2d_n16cx_gemm_direct_blk1x14_kernel_fp32_avx512.h
@@ -173,11 +173,7 @@ void conv2d_n16cx_gemm_direct_fp32_avx512_blk1x14_kernel_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 6f\n" // label_ic_remain
 "5:\n" // label_ic_body
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
         ".if HW_LEN < 6\n"
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm28\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/avx512/conv2d_n16cx_gemm_direct_blk1x31_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/avx512/conv2d_n16cx_gemm_direct_blk1x31_kernel_fp32_avx512.h
@@ -177,11 +177,7 @@ void conv2d_n16cx_gemm_direct_fp32_avx512_blk1x31_kernel_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 6f\n" // label_ic_remain
 "5:\n" // label_ic_body
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
         ".if HW_LEN < 9\n"
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm31\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/avx512/conv2d_n16cx_gemm_direct_blk1x31_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/avx512/conv2d_n16cx_gemm_direct_blk1x31_kernel_fp32_avx512.h
@@ -177,7 +177,11 @@ void conv2d_n16cx_gemm_direct_fp32_avx512_blk1x31_kernel_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 6f\n" // label_ic_remain
 "5:\n" // label_ic_body
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
         ".if HW_LEN < 9\n"
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm31\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/fma/conv2d_n16cx_gemm_direct_kernel_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/fma/conv2d_n16cx_gemm_direct_kernel_fp32_fma.cpp
@@ -155,7 +155,11 @@ void conv2d_n16cx_gemm_direct_fp32_fma_blk1x6_kernel_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 6f\n" // label_ic_remain
 "5:\n" // label_ic_body
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups ((\\IC * CH_DT_BLK + 0 * CH_RF_BLK) * D_BYTES)(%%rbx), %%ymm14\n"
         "vmovups ((\\IC * CH_DT_BLK + 1 * CH_RF_BLK) * D_BYTES)(%%rbx), %%ymm15\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/fma/conv2d_n16cx_gemm_direct_kernel_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/fma/conv2d_n16cx_gemm_direct_kernel_fp32_fma.cpp
@@ -155,11 +155,7 @@ void conv2d_n16cx_gemm_direct_fp32_fma_blk1x6_kernel_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 6f\n" // label_ic_remain
 "5:\n" // label_ic_body
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups ((\\IC * CH_DT_BLK + 0 * CH_RF_BLK) * D_BYTES)(%%rbx), %%ymm14\n"
         "vmovups ((\\IC * CH_DT_BLK + 1 * CH_RF_BLK) * D_BYTES)(%%rbx), %%ymm15\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/im2col_gemm/avx512/conv2d_im2col_gemm_o31_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/im2col_gemm/avx512/conv2d_im2col_gemm_o31_kernel_fp32_avx512.h
@@ -135,11 +135,7 @@ inline void conv2d_im2col_gemm_o31_kernel_fp32_avx512_core(
         "cmp $NK_DT_BLK, %%r10\n"
         "jl 6f\n" // label_ic_remain
 "4:\n" // label_ic_body
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
         ".if O_LEN < 9\n"
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * NK_DT_BLK * D_BYTES)(%%rbx), %%zmm31\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/im2col_gemm/avx512/conv2d_im2col_gemm_o31_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/im2col_gemm/avx512/conv2d_im2col_gemm_o31_kernel_fp32_avx512.h
@@ -135,7 +135,11 @@ inline void conv2d_im2col_gemm_o31_kernel_fp32_avx512_core(
         "cmp $NK_DT_BLK, %%r10\n"
         "jl 6f\n" // label_ic_remain
 "4:\n" // label_ic_body
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
         ".if O_LEN < 9\n"
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * NK_DT_BLK * D_BYTES)(%%rbx), %%zmm31\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t14_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t14_kernel_fp32_avx512.h
@@ -126,11 +126,7 @@ void conv2d_n16cx_winograd_t14_kernel_fp32_avx512_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 5f\n" // label_ic_remain
 "4:\n" // label_ic_body
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
         ".if T_LEN < 6\n"
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm28\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t14_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t14_kernel_fp32_avx512.h
@@ -126,7 +126,11 @@ void conv2d_n16cx_winograd_t14_kernel_fp32_avx512_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 5f\n" // label_ic_remain
 "4:\n" // label_ic_body
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
         ".if T_LEN < 6\n"
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm28\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t31_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t31_kernel_fp32_avx512.h
@@ -128,11 +128,7 @@ inline void conv2d_n16cx_winograd_t31_kernel_fp32_avx512_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 6f\n" // label_ic_remain
 "4:\n" // label_ic_body
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
         ".if T_LEN < 9\n"
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm31\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t31_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t31_kernel_fp32_avx512.h
@@ -128,7 +128,11 @@ inline void conv2d_n16cx_winograd_t31_kernel_fp32_avx512_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 6f\n" // label_ic_remain
 "4:\n" // label_ic_body
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
         ".if T_LEN < 9\n"
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm31\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t6_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t6_kernel_fp32_avx512.h
@@ -128,7 +128,11 @@ void conv2d_n16cx_winograd_t6_kernel_fp32_avx512_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 5f\n" // label_ic_remain
 "4:\n" // label_ic_body
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm26\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rcx), %%zmm27\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t6_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t6_kernel_fp32_avx512.h
@@ -128,11 +128,7 @@ void conv2d_n16cx_winograd_t6_kernel_fp32_avx512_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 5f\n" // label_ic_remain
 "4:\n" // label_ic_body
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm26\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rcx), %%zmm27\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t9_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t9_kernel_fp32_avx512.h
@@ -130,7 +130,11 @@ void conv2d_n16cx_winograd_t9_kernel_fp32_avx512_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 5f\n" // label_ic_remain
 "4:\n" // label_ic_body
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm27\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rcx), %%zmm28\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t9_kernel_fp32_avx512.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_t9_kernel_fp32_avx512.h
@@ -130,11 +130,7 @@ void conv2d_n16cx_winograd_t9_kernel_fp32_avx512_core(
         "cmp $CH_DT_BLK, %%r10\n"
         "jl 5f\n" // label_ic_remain
 "4:\n" // label_ic_body
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rbx), %%zmm27\n"
         "vmovups (\\IC * CH_DT_BLK * D_BYTES)(%%rcx), %%zmm28\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/fma/conv2d_n16cx_winograd_kernel_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/fma/conv2d_n16cx_winograd_kernel_fp32_fma.cpp
@@ -104,11 +104,7 @@ void conv2d_n16cx_winograd_kernel_fp32_fma_core(
         "cmp $CH_DT_BLK, %%r13\n"
         "jl 3f\n" // label_loop_c
 
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
 "2:\n" // label_loop_16c
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups ((\\IC * CH_DT_BLK + 0 * CH_RF_BLK) * DBYTES)(%%r14), %%ymm14\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/fma/conv2d_n16cx_winograd_kernel_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/winograd/fma/conv2d_n16cx_winograd_kernel_fp32_fma.cpp
@@ -104,7 +104,11 @@ void conv2d_n16cx_winograd_kernel_fp32_fma_core(
         "cmp $CH_DT_BLK, %%r13\n"
         "jl 3f\n" // label_loop_c
 
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
 "2:\n" // label_loop_16c
         ".irp IC,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15\n"
         "vmovups ((\\IC * CH_DT_BLK + 0 * CH_RF_BLK) * DBYTES)(%%r14), %%ymm14\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/gemm/kernel/fma/gemm_nn_bcasta_vloadb_kernel_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/gemm/kernel/fma/gemm_nn_bcasta_vloadb_kernel_fp32_fma.cpp
@@ -71,11 +71,7 @@ void gemm_nn_bcasta_vloadb_m6n16k16_fp32_fma_kernel_core(
         ".equ KER_FORM_GEMM, 1\n"
         ".equ KER_FORM_CONV, 2\n"
 
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
         ".if KER_FORM != KER_FORM_NONE\n"
         "mov H_IDX(%[priv_param]), %%r15\n" // mb_h
         ".endif\n" // .if KER_FORM != KER_FORM_NONE
@@ -153,11 +149,7 @@ void gemm_nn_bcasta_vloadb_m6n16k16_fp32_fma_kernel_core(
         "cmp $M6_K_DT_BLK, %%r10\n"
         "jl 5f\n" // label_k_remain
 "4:\n" // label_k_body
-#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
-        ".align 4\n"
-#else
-        ".align 16\n"
-#endif
+        PPL_X86_INLINE_ASM_ALIGN()
         "lea (%%rax, %%r11, D_BYTES), %%rcx\n"
         ".if PREFETCH_A\n"
         ".if M_LEN > 0\n prefetcht0 (0 * M6_K_DT_BLK * D_BYTES)(%%rcx)\n .endif\n"

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/gemm/kernel/fma/gemm_nn_bcasta_vloadb_kernel_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/gemm/kernel/fma/gemm_nn_bcasta_vloadb_kernel_fp32_fma.cpp
@@ -71,7 +71,11 @@ void gemm_nn_bcasta_vloadb_m6n16k16_fp32_fma_kernel_core(
         ".equ KER_FORM_GEMM, 1\n"
         ".equ KER_FORM_CONV, 2\n"
 
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
         ".if KER_FORM != KER_FORM_NONE\n"
         "mov H_IDX(%[priv_param]), %%r15\n" // mb_h
         ".endif\n" // .if KER_FORM != KER_FORM_NONE
@@ -149,7 +153,11 @@ void gemm_nn_bcasta_vloadb_m6n16k16_fp32_fma_kernel_core(
         "cmp $M6_K_DT_BLK, %%r10\n"
         "jl 5f\n" // label_k_remain
 "4:\n" // label_k_body
+#if defined(__APPLE__) && (defined(__GNUC__) || defined(__xlC__) || defined(__xlc__))
+        ".align 4\n"
+#else
         ".align 16\n"
+#endif
         "lea (%%rax, %%r11, D_BYTES), %%rcx\n"
         ".if PREFETCH_A\n"
         ".if M_LEN > 0\n prefetcht0 (0 * M6_K_DT_BLK * D_BYTES)(%%rcx)\n .endif\n"


### PR DESCRIPTION
Continue with issue #46, the `.align 16` directive inline assembly means different with Clang on Darwin and GCC on Linux.

In Clang of Darwin, `.align 16` means align with 2^16, which should be corrected with `.align 4`.

I've done plenty of test, showed that the performance problem is solved.