### PR TITLE
N8CX format `direct conv2d sse` and `reorder`

### DIFF
--- a/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/fp32/reorder.h
+++ b/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/fp32/reorder.h
@@ -52,6 +52,16 @@ ppl::common::RetCode reorder_n16cx_nxc_fp32(
     const float *src,
     float *dst);
 
+ppl::common::RetCode reorder_ndarray_n8cx_fp32(
+    const ppl::nn::TensorShape *src_shape,
+    const float *src,
+    float *dst);
+
+ppl::common::RetCode reorder_n8cx_ndarray_fp32(
+    const ppl::nn::TensorShape *src_shape,
+    const float *src,
+    float *dst);
+
 uint64_t reorder_goidhw_gIOdhwB16i16o_fp32_get_dst_size(
     const int32_t group,
     const int32_t num_output,
@@ -108,6 +118,26 @@ ppl::common::RetCode reorder_goidhw_gOdhwi16o_fp32(
     const int32_t kernel_d,
     const int32_t kernel_h,
     const int32_t kernel_w,
+    float *dst);
+
+uint64_t reorder_goidhw_gIOBidhw8i8o_fp32_get_dst_size(
+    const int32_t group,
+    const int32_t num_output,
+    const int32_t channels,
+    const int32_t kernel_d,
+    const int32_t kernel_h,
+    const int32_t kernel_w,
+    const int32_t channels_blk);
+
+ppl::common::RetCode reorder_goidhw_gIOBidhw8i8o_fp32(
+    const float *src,
+    const int32_t group,
+    const int32_t num_output,
+    const int32_t channels,
+    const int32_t kernel_d,
+    const int32_t kernel_h,
+    const int32_t kernel_w,
+    const int32_t channels_blk,
     float *dst);
 
 }}}; // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/common/math_sse.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/common/math_sse.h
@@ -18,7 +18,7 @@
 #ifndef __ST_PPL_KERNEL_X86_COMMON_MATH_SSE_H_
 #define __ST_PPL_KERNEL_X86_COMMON_MATH_SSE_H_
 
-#include <xmmintrin.h>
+#include <nmmintrin.h>
 
 namespace ppl { namespace kernel { namespace x86 {
 

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/common/sse_tools.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/common/sse_tools.h
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_COMMON_SSE_TOOLS_H_
+#define __ST_PPL_KERNEL_X86_COMMON_SSE_TOOLS_H_
+
+#include <stdint.h>
+#include <nmmintrin.h>
+
+namespace ppl { namespace kernel { namespace x86 {
+
+inline void memset32_sse(void *dst, const int32_t val, const int64_t n32) {
+    int64_t __n32 = n32;
+    int32_t *__dst = (int32_t*)dst;
+    if (__n32 >= 4) {
+        __m128 xmm_val = _mm_set1_ps(*reinterpret_cast<const float *>(&val));
+        while (__n32 >= 16) {
+            _mm_storeu_ps(reinterpret_cast<float *>(__dst + 0), xmm_val);
+            _mm_storeu_ps(reinterpret_cast<float *>(__dst + 4), xmm_val);
+            _mm_storeu_ps(reinterpret_cast<float *>(__dst + 8), xmm_val);
+            _mm_storeu_ps(reinterpret_cast<float *>(__dst + 12), xmm_val);
+            __dst += 16;
+            __n32 -= 16;
+        }
+        if (__n32 & 8) {
+            _mm_storeu_ps(reinterpret_cast<float *>(__dst + 0), xmm_val);
+            _mm_storeu_ps(reinterpret_cast<float *>(__dst + 4), xmm_val);
+            __dst += 8;
+            __n32 -= 8;
+        }
+        if (__n32 & 4) {
+            _mm_storeu_ps(reinterpret_cast<float *>(__dst + 0), xmm_val);
+            __dst += 4;
+            __n32 -= 4;
+        }
+    }
+    if (__n32 & 2) {
+        __dst[0] = val;
+        __dst[1] = val;
+        __dst += 2;
+        __n32 -= 2;
+    }
+    if (__n32 & 1) {
+        __dst[0] = val;
+    }
+}
+
+inline void memcpy32_sse(void *dst, const void *src, const int64_t n32) {
+    int64_t __n32 = n32;
+    float *__dst = (float*)dst;
+    const float *__src = (const float*)src;
+    while (__n32 >= 16) {
+        _mm_storeu_ps(__dst + 0, _mm_loadu_ps(__src + 0));
+        _mm_storeu_ps(__dst + 4, _mm_loadu_ps(__src + 4));
+        _mm_storeu_ps(__dst + 8, _mm_loadu_ps(__src + 8));
+        _mm_storeu_ps(__dst + 12, _mm_loadu_ps(__src + 12));
+        __dst += 16;
+        __src += 16;
+        __n32 -= 16;
+    }
+    if (__n32 & 8) {
+        _mm_storeu_ps(__dst + 0, _mm_loadu_ps(__src + 0));
+        _mm_storeu_ps(__dst + 4, _mm_loadu_ps(__src + 4));
+        __dst += 8;
+        __src += 8;
+        __n32 -= 8;
+    }
+    if (__n32 & 4) {
+        _mm_storeu_ps(__dst + 0, _mm_loadu_ps(__src + 0));
+        __dst += 4;
+        __src += 4;
+        __n32 -= 4;
+    }
+    if (__n32 & 2) {
+        __dst[0] = __src[0];
+        __dst[1] = __src[1];
+        __dst += 2;
+        __src += 2;
+        __n32 -= 2;
+    }
+    if (__n32 & 1) {
+        __dst[0] = __src[0];
+    }
+}
+
+}}}; // namespace ppl::kernel::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/conv2d_fp32_common.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/conv2d_fp32_common.cpp
@@ -37,6 +37,8 @@
 #include "ppl/kernel/x86/fp32/conv2d/winograd/avx512/conv2d_n16cx_winograd_b4f3_fp32_avx512.h"
 #endif
 
+#include "ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_fp32_sse.h"
+
 namespace ppl { namespace kernel { namespace x86 {
 
 conv2d_fp32_algo_info conv2d_algo_selector::select_algo(const ppl::common::dataformat_t src_format, const conv2d_fp32_param &param, const ppl::common::isa_t isa_flags)
@@ -291,6 +293,12 @@ conv2d_fp32_manager *conv2d_algo_selector::gen_algo(const conv2d_fp32_param &par
         conv_mgr = new conv2d_n16cx_depthwise_fp32_avx512_manager(param, allocator);
     }
 #endif
+    if (algo_info.algo_type == conv2d_fp32_algo::direct &&
+        algo_info.isa == ppl::common::ISA_X86_SSE &&
+        algo_info.input_format == ppl::common::DATAFORMAT_N8CX &&
+        algo_info.output_format == ppl::common::DATAFORMAT_N8CX) {
+        conv_mgr = new conv2d_n8cx_direct_fp32_sse_manager(param, allocator);
+    }
 
     return conv_mgr;
 }

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/avx512/conv2d_n16cx_direct_fp32_avx512.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/avx512/conv2d_n16cx_direct_fp32_avx512.cpp
@@ -92,7 +92,7 @@ void conv2d_n16cx_direct_fp32_avx512_executor::cal_kernel_tunning_param()
     }
     sp.mb_l3_blk = min<int32_t>(batch, div_up(num_thread, sp.gp_l3_blk));
     while (sp.mb_l3_blk > 1 && sp.gp_l3_blk * sp.mb_l3_blk * sp.ic_l2_blk * padded_src_hw > l3_cap_all_core) {
-            --sp.mb_l3_blk;
+        --sp.mb_l3_blk;
     }
 
     if (dst_h <= 112 && dst_w <= 112
@@ -436,8 +436,8 @@ bool conv2d_n16cx_direct_fp32_avx512_manager::is_supported()
     if (param_.is_pointwise()) {
         return false;
     }
-    bool aligned_channels   = param_.channels / param_.group % 16 == 0;
-    bool aligned_num_output = param_.num_output / param_.group % 16 == 0;
+    bool aligned_channels   = param_.channels / param_.group % CH_DT_BLK() == 0;
+    bool aligned_num_output = param_.num_output / param_.group % CH_DT_BLK() == 0;
     return (param_.group == 1) || (aligned_channels && aligned_num_output);
 }
 

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/fma/conv2d_n16cx_direct_v2_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/fma/conv2d_n16cx_direct_v2_fp32_fma.cpp
@@ -441,8 +441,8 @@ bool conv2d_n16cx_direct_v2_fp32_fma_manager::is_supported()
     if (param_.is_pointwise()) {
         return false;
     }
-    bool aligned_channels   = param_.channels / param_.group % 16 == 0;
-    bool aligned_num_output = param_.num_output / param_.group % 16 == 0;
+    bool aligned_channels   = param_.channels / param_.group % CH_DT_BLK() == 0;
+    bool aligned_num_output = param_.num_output / param_.group % CH_DT_BLK() == 0;
     return (param_.group == 1) || (aligned_channels && aligned_num_output);
 }
 

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_blk1x1_kernel_fp32_sse.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_blk1x1_kernel_fp32_sse.h
@@ -1,0 +1,207 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_FP32_CONV2D_DIRECT_SSE_CONV2D_N8CX_DIRECT_BLK1X1_KERNEL_FP32_SSE_H_
+#define __ST_PPL_KERNEL_X86_FP32_CONV2D_DIRECT_SSE_CONV2D_N8CX_DIRECT_BLK1X1_KERNEL_FP32_SSE_H_
+
+#include <nmmintrin.h>
+
+#include "ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_kernel_fp32_sse.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+template <bool nt_store, int32_t oc_len>
+void conv2d_n8cx_direct_fp32_sse_blk1x1_kernel(
+    const int64_t *shar_param,
+    int64_t *priv_param)
+{
+#define IC_COMPUTE_STEP(IC) do {\
+    xmm4 = _mm_set1_ps(ic_src[(IC)]);\
+    if (oc_len > 0 * CH_DT_BLK()) {\
+        xmm5 = _mm_loadu_ps(ic_flt + 0 * flt_ocb_stride + (IC) * CH_DT_BLK() + 0 * CH_RF_BLK());\
+        xmm5 = _mm_mul_ps(xmm5, xmm4);\
+        xmm0 = _mm_add_ps(xmm0, xmm5);\
+        xmm6 = _mm_loadu_ps(ic_flt + 0 * flt_ocb_stride + (IC) * CH_DT_BLK() + 1 * CH_RF_BLK());\
+        xmm6 = _mm_mul_ps(xmm6, xmm4);\
+        xmm1 = _mm_add_ps(xmm1, xmm6);\
+    }\
+    if (oc_len > 1 * CH_DT_BLK()) {\
+        xmm7 = _mm_loadu_ps(ic_flt + 1 * flt_ocb_stride + (IC) * CH_DT_BLK() + 0 * CH_RF_BLK());\
+        xmm7 = _mm_mul_ps(xmm7, xmm4);\
+        xmm2 = _mm_add_ps(xmm2, xmm7);\
+        xmm8 = _mm_loadu_ps(ic_flt + 1 * flt_ocb_stride + (IC) * CH_DT_BLK() + 1 * CH_RF_BLK());\
+        xmm8 = _mm_mul_ps(xmm8, xmm4);\
+        xmm3 = _mm_add_ps(xmm3, xmm8);\
+    }\
+} while (0)
+
+    __m128 xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
+    __m128 xmm8, xmm9, xmm10; // xmm11, xmm12, xmm13, xmm14, xmm15;
+
+    const uint64_t kernel_flags = PICK_PARAM(const uint64_t, shar_param, FLAGS_IDX());
+    if (kernel_flags & (KERNEL_FLAG_RELU() | KERNEL_FLAG_RELU6())) {
+        xmm9 = _mm_setzero_ps();
+    }
+    if (kernel_flags & KERNEL_FLAG_RELU6()) {
+        xmm10 = _mm_set1_ps(6.0f);
+    }
+
+    if (kernel_flags & KERNEL_FLAG_LD_BIAS()) {
+        const float* bias = PICK_PARAM(const float*, priv_param, BIAS_IDX());
+        if (oc_len > 0 * CH_DT_BLK()) {
+            xmm0 = _mm_loadu_ps(bias + 0 * CH_DT_BLK() + 0 * CH_RF_BLK());
+            xmm1 = _mm_loadu_ps(bias + 0 * CH_DT_BLK() + 1 * CH_RF_BLK());
+        }
+        if (oc_len > 1 * CH_DT_BLK()) {
+            xmm2 = _mm_loadu_ps(bias + 1 * CH_DT_BLK() + 0 * CH_RF_BLK());
+            xmm3 = _mm_loadu_ps(bias + 1 * CH_DT_BLK() + 1 * CH_RF_BLK());
+        }
+    } else {
+        const float* his = PICK_PARAM(const float*, priv_param, HIS_IDX());
+        const int64_t his_ocb_stride = shar_param[HIS_OCB_STRIDE_IDX()];
+        if (oc_len > 0 * CH_DT_BLK()) {
+            xmm0 = _mm_loadu_ps(his + 0 * CH_RF_BLK());
+            xmm1 = _mm_loadu_ps(his + 1 * CH_RF_BLK());
+        }
+        if (oc_len > 1 * CH_DT_BLK()) {
+            his += his_ocb_stride;
+            xmm2 = _mm_loadu_ps(his + 0 * CH_RF_BLK());
+            xmm3 = _mm_loadu_ps(his + 1 * CH_RF_BLK());
+        }
+    }
+
+    if (kernel_flags & KERNEL_FLAG_AD_BIAS()) {
+        const float* bias = PICK_PARAM(const float*, priv_param, BIAS_IDX());
+        if (oc_len > 0 * CH_DT_BLK()) {
+            xmm4 = _mm_loadu_ps(bias + 0 * CH_DT_BLK() + 0 * CH_RF_BLK());
+            xmm0 = _mm_add_ps(xmm4, xmm0);
+            xmm5 = _mm_loadu_ps(bias + 0 * CH_DT_BLK() + 0 * CH_RF_BLK());
+            xmm1 = _mm_add_ps(xmm5, xmm1);
+        }
+        if (oc_len > 1 * CH_DT_BLK()) {
+            xmm6 = _mm_loadu_ps(bias + 1 * CH_DT_BLK() + 0 * CH_RF_BLK());
+            xmm2 = _mm_add_ps(xmm6, xmm2);
+            xmm7 = _mm_loadu_ps(bias + 1 * CH_DT_BLK() + 1 * CH_RF_BLK());
+            xmm3 = _mm_add_ps(xmm7, xmm3);
+        }
+    }
+
+    const int64_t kernel_h = shar_param[KH_IDX()];
+    const int64_t kernel_w = shar_param[KW_IDX()];
+    const int64_t src_icb_stride = shar_param[SRC_ICB_STRIDE_IDX()];
+    const int64_t src_dh_stride = shar_param[SRC_DH_STRIDE_IDX()];
+    const int64_t src_dw_stride = shar_param[SRC_DW_STRIDE_IDX()];
+    const int64_t src_sw_stride = shar_param[SRC_SW_STRIDE_IDX()];
+    const int64_t flt_ocb_stride = shar_param[FLT_OCB_STRIDE_IDX()];
+    const int64_t kh_start = priv_param[KH_START_IDX()];
+    const int64_t kh_end = priv_param[KH_END_IDX()];
+    const int64_t kw_start = priv_param[KW_START_IDX()];
+    const int64_t kw_end = priv_param[KW_END_IDX()];
+
+    const float *icb_src = PICK_PARAM(const float*, priv_param, SRC_IDX()) + kh_start * src_dh_stride;
+    const float *icb_flt = PICK_PARAM(const float*, priv_param, FLT_IDX()) + kh_start * kernel_w * CH_DT_BLK() * CH_DT_BLK();
+    int64_t channels = shar_param[CHANNELS_IDX()];
+    do {
+        const float *kh_src = icb_src;
+        const float *kh_flt = icb_flt;
+        for (int64_t kh = kh_start; kh < kh_end; ++kh) {
+            const float *kw_src = kh_src + kw_start * src_dw_stride;
+            const float *kw_flt = kh_flt + kw_start * CH_DT_BLK() * CH_DT_BLK();
+            for (int64_t kw = kw_start; kw < kw_end; ++kw) {
+                if (channels >= CH_DT_BLK()) {
+                    const float *ic_src = kw_src;
+                    const float *ic_flt = kw_flt;
+                    for (int64_t ic = 0; ic < CH_DT_BLK(); ++ic) {
+                        IC_COMPUTE_STEP(0);
+                        ic_src += 1;
+                        ic_flt += CH_DT_BLK();
+                    }
+                } else {
+                    const float *ic_src = kw_src;
+                    const float *ic_flt = kw_flt;
+                    for (int64_t ic = 0; ic < channels; ++ic) {
+                        IC_COMPUTE_STEP(0);
+                        ic_src += 1;
+                        ic_flt += CH_DT_BLK();
+                    }
+                }
+                kw_flt += CH_DT_BLK() * CH_DT_BLK();
+                kw_src += src_dw_stride;
+            }
+            kh_flt += kernel_w * CH_DT_BLK() * CH_DT_BLK();
+            kh_src += src_dh_stride;
+        }
+        icb_flt += kernel_h * kernel_w * CH_DT_BLK() * CH_DT_BLK();
+        icb_src += src_icb_stride;
+        channels -= CH_DT_BLK();
+    } while (channels > 0);
+    
+    if (kernel_flags & (KERNEL_FLAG_RELU() | KERNEL_FLAG_RELU6())) {
+        if (oc_len > 0 * CH_DT_BLK()) {
+            xmm0 = _mm_max_ps(xmm0, xmm9);
+            xmm1 = _mm_max_ps(xmm1, xmm9);
+        }
+        if (oc_len > 1 * CH_DT_BLK()) {
+            xmm2 = _mm_max_ps(xmm2, xmm9);
+            xmm3 = _mm_max_ps(xmm3, xmm9);
+        }
+    }
+    if (kernel_flags & KERNEL_FLAG_RELU6()) {
+        if (oc_len > 0 * CH_DT_BLK()) {
+            xmm0 = _mm_min_ps(xmm0, xmm10);
+            xmm1 = _mm_min_ps(xmm1, xmm10);
+        }
+        if (oc_len > 1 * CH_DT_BLK()) {
+            xmm2 = _mm_min_ps(xmm2, xmm10);
+            xmm3 = _mm_min_ps(xmm3, xmm10);
+        }
+    }
+
+    if (nt_store) {
+        float* dst = PICK_PARAM(float*, priv_param, DST_IDX());
+        const int64_t dst_ocb_stride = shar_param[DST_OCB_STRIDE_IDX()];
+        if (oc_len > 0 * CH_DT_BLK()) {
+            _mm_stream_ps(dst + 0 * CH_RF_BLK(), xmm0);
+            _mm_stream_ps(dst + 1 * CH_RF_BLK(), xmm1);
+        }
+        if (oc_len > 1 * CH_DT_BLK()) {
+            dst += dst_ocb_stride;
+            _mm_stream_ps(dst + 0 * CH_RF_BLK(), xmm2);
+            _mm_stream_ps(dst + 1 * CH_RF_BLK(), xmm3);
+        }
+    } else {
+        float* dst = PICK_PARAM(float*, priv_param, DST_IDX());
+        const int64_t dst_ocb_stride = shar_param[DST_OCB_STRIDE_IDX()];
+        if (oc_len > 0 * CH_DT_BLK()) {
+            _mm_storeu_ps(dst + 0 * CH_RF_BLK(), xmm0);
+            _mm_storeu_ps(dst + 1 * CH_RF_BLK(), xmm1);
+        }
+        if (oc_len > 1 * CH_DT_BLK()) {
+            dst += dst_ocb_stride;
+            _mm_storeu_ps(dst + 0 * CH_RF_BLK(), xmm2);
+            _mm_storeu_ps(dst + 1 * CH_RF_BLK(), xmm3);
+        }
+    }
+    PICK_PARAM(const float *, priv_param, SRC_IDX()) += src_sw_stride;
+    PICK_PARAM(const float *, priv_param, HIS_IDX()) += CH_DT_BLK();
+    PICK_PARAM(float *, priv_param, DST_IDX()) += CH_DT_BLK();
+#undef IC_COMPUTE_STEP
+}
+
+}}};
+
+#endif

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_blk1x3_kernel_fp32_sse.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_blk1x3_kernel_fp32_sse.h
@@ -1,0 +1,412 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_FP32_CONV2D_DIRECT_SSE_CONV2D_N8CX_DIRECT_BLK1X3_KERNEL_FP32_SSE_H_
+#define __ST_PPL_KERNEL_X86_FP32_CONV2D_DIRECT_SSE_CONV2D_N8CX_DIRECT_BLK1X3_KERNEL_FP32_SSE_H_
+
+#include <nmmintrin.h>
+
+#include "ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_kernel_fp32_sse.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+template <bool nt_store, int32_t spec_stride_w, int32_t oc_len, int32_t w_len>
+void conv2d_n8cx_direct_fp32_sse_blk1x3_kernel(
+    const int64_t *shar_param,
+    int64_t *priv_param)
+{
+#define IC_COMPUTE_STEP(IC) do {\
+    if (w_len > 0) {\
+        xmm12 = _mm_set1_ps(ic_src[(IC) + 0 * src_sw_stride]);\
+        if (oc_len > 0 * CH_DT_BLK()) {\
+            xmm15 = _mm_loadu_ps(ic_flt_o8 + (IC) * CH_DT_BLK() + 0 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm12);\
+            xmm0 = _mm_add_ps(xmm0, xmm15);\
+            xmm15 = _mm_loadu_ps(ic_flt_o8 + (IC) * CH_DT_BLK() + 1 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm12);\
+            xmm1 = _mm_add_ps(xmm1, xmm15);\
+        }\
+        if (oc_len > 1 * CH_DT_BLK()) {\
+            xmm15 = _mm_loadu_ps(ic_flt_o16 + (IC) * CH_DT_BLK() + 0 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm12);\
+            xmm6 = _mm_add_ps(xmm6, xmm15);\
+            xmm15 = _mm_loadu_ps(ic_flt_o16 + (IC) * CH_DT_BLK() + 1 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm12);\
+            xmm7 = _mm_add_ps(xmm7, xmm15);\
+        }\
+    }\
+    if (w_len > 1) {\
+        xmm13 = _mm_set1_ps(ic_src[(IC) + 1 * src_sw_stride]);\
+        if (oc_len > 0 * CH_DT_BLK()) {\
+            xmm15 = _mm_loadu_ps(ic_flt_o8 + (IC) * CH_DT_BLK() + 0 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm13);\
+            xmm2 = _mm_add_ps(xmm2, xmm15);\
+            xmm15 = _mm_loadu_ps(ic_flt_o8 + (IC) * CH_DT_BLK() + 1 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm13);\
+            xmm3 = _mm_add_ps(xmm3, xmm15);\
+        }\
+        if (oc_len > 1 * CH_DT_BLK()) {\
+            xmm15 = _mm_loadu_ps(ic_flt_o16 + (IC) * CH_DT_BLK() + 0 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm13);\
+            xmm8 = _mm_add_ps(xmm8, xmm15);\
+            xmm15 = _mm_loadu_ps(ic_flt_o16 + (IC) * CH_DT_BLK() + 1 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm13);\
+            xmm9 = _mm_add_ps(xmm9, xmm15);\
+        }\
+    }\
+    if (w_len > 2) {\
+        xmm14 = _mm_set1_ps(ic_src[(IC) + 2 * src_sw_stride]);\
+        if (oc_len > 0 * CH_DT_BLK()) {\
+            xmm15 = _mm_loadu_ps(ic_flt_o8 + (IC) * CH_DT_BLK() + 0 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm14);\
+            xmm4 = _mm_add_ps(xmm4, xmm15);\
+            xmm15 = _mm_loadu_ps(ic_flt_o8 + (IC) * CH_DT_BLK() + 1 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm14);\
+            xmm5 = _mm_add_ps(xmm5, xmm15);\
+        }\
+        if (oc_len > 1 * CH_DT_BLK()) {\
+            xmm15 = _mm_loadu_ps(ic_flt_o16 + (IC) * CH_DT_BLK() + 0 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm14);\
+            xmm10 = _mm_add_ps(xmm10, xmm15);\
+            xmm15 = _mm_loadu_ps(ic_flt_o16 + (IC) * CH_DT_BLK() + 1 * CH_RF_BLK());\
+            xmm15 = _mm_mul_ps(xmm15, xmm14);\
+            xmm11 = _mm_add_ps(xmm11, xmm15);\
+        }\
+    }\
+} while (0)
+
+#define IC_PREFETCH_STEP(IC)  do {\
+    if (oc_len > 1 * CH_DT_BLK() && w_len > 1) {\
+        if (oc_len > 0 * CH_DT_BLK()) _mm_prefetch((const char*)ic_flt_o8 + 0 * flt_ocb_stride + (IC) * CH_DT_BLK() + CH_DT_BLK() * CH_DT_BLK(), _MM_HINT_T0);\
+        if (oc_len > 1 * CH_DT_BLK()) _mm_prefetch((const char*)ic_flt_o16 + 0 * flt_ocb_stride + (IC) * CH_DT_BLK() + CH_DT_BLK() * CH_DT_BLK(), _MM_HINT_T0);\
+    }\
+} while (0)
+
+    __m128 xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
+    __m128 xmm8, xmm9, xmm10, xmm11, xmm12, xmm13, xmm14, xmm15;
+
+    const int64_t kernel_h = shar_param[KH_IDX()];
+    const int64_t kernel_w = shar_param[KW_IDX()];
+    const int64_t src_icb_stride = shar_param[SRC_ICB_STRIDE_IDX()];
+    const int64_t src_sw_stride = spec_stride_w ? spec_stride_w * CH_DT_BLK() : shar_param[SRC_SW_STRIDE_IDX()];
+    const int64_t src_dw_stride = shar_param[SRC_DW_STRIDE_IDX()];
+    const int64_t src_dh_stride = shar_param[SRC_DH_STRIDE_IDX()] - kernel_w * src_dw_stride;
+    const int64_t flt_ocb_stride = shar_param[FLT_OCB_STRIDE_IDX()];
+    const int64_t kernel_flags = shar_param[FLAGS_IDX()];
+    const int64_t kh_start = priv_param[KH_START_IDX()];
+    const int64_t kh_end = priv_param[KH_END_IDX()];
+
+    const float *src = PICK_PARAM(const float*, priv_param, SRC_IDX());
+    const float *his = PICK_PARAM(const float*, priv_param, HIS_IDX());
+    float *dst       = PICK_PARAM(float*, priv_param, DST_IDX());
+    int64_t ow       = priv_param[OW_IDX()];
+    do {
+        if (kernel_flags & KERNEL_FLAG_LD_BIAS()) {
+            const float* bias = PICK_PARAM(const float*, priv_param, BIAS_IDX());
+            if (oc_len > 0 * CH_DT_BLK()) {
+                if (w_len > 0) {
+                    xmm0 = _mm_loadu_ps(bias + 0 * CH_DT_BLK() + 0 * CH_RF_BLK());
+                    xmm1 = _mm_loadu_ps(bias + 0 * CH_DT_BLK() + 1 * CH_RF_BLK());
+                }
+                if (w_len > 1) {
+                    xmm2 = xmm0;
+                    xmm3 = xmm1;
+                }
+                if (w_len > 2) {
+                    xmm4 = xmm0;
+                    xmm5 = xmm1;
+                }
+            }
+            if (oc_len > 1 * CH_DT_BLK()) {
+                if (w_len > 0) {
+                    xmm6 = _mm_loadu_ps(bias + 1 * CH_DT_BLK() + 0 * CH_RF_BLK());
+                    xmm7 = _mm_loadu_ps(bias + 1 * CH_DT_BLK() + 1 * CH_RF_BLK());
+                }
+                if (w_len > 1) {
+                    xmm8 = xmm6;
+                    xmm9 = xmm7;
+                }
+                if (w_len > 2) {
+                    xmm10 = xmm6;
+                    xmm11 = xmm7;
+                }
+            }
+        } else {
+            const float *l_his = his;
+            const int64_t his_ocb_stride = shar_param[HIS_OCB_STRIDE_IDX()];
+            if (oc_len > 0 * CH_DT_BLK()) {
+                if (w_len > 0) {
+                    xmm0 = _mm_loadu_ps(l_his + 0 * CH_DT_BLK() + 0 * CH_RF_BLK());
+                    xmm1 = _mm_loadu_ps(l_his + 0 * CH_DT_BLK() + 1 * CH_RF_BLK());
+                }
+                if (w_len > 1) {
+                    xmm2 = _mm_loadu_ps(l_his + 1 * CH_DT_BLK() + 0 * CH_RF_BLK());
+                    xmm3 = _mm_loadu_ps(l_his + 1 * CH_DT_BLK() + 1 * CH_RF_BLK());
+                }
+                if (w_len > 2) {
+                    xmm4 = _mm_loadu_ps(l_his + 2 * CH_DT_BLK() + 0 * CH_RF_BLK());
+                    xmm5 = _mm_loadu_ps(l_his + 2 * CH_DT_BLK() + 1 * CH_RF_BLK());
+                }
+            }
+            if (oc_len > 1 * CH_DT_BLK()) {
+                l_his += his_ocb_stride;
+                if (w_len > 0) {
+                    xmm6 = _mm_loadu_ps(l_his + 0 * CH_DT_BLK() + 0 * CH_RF_BLK());
+                    xmm7 = _mm_loadu_ps(l_his + 0 * CH_DT_BLK() + 1 * CH_RF_BLK());
+                }
+                if (w_len > 1) {
+                    xmm8 = _mm_loadu_ps(l_his + 1 * CH_DT_BLK() + 0 * CH_RF_BLK());
+                    xmm9 = _mm_loadu_ps(l_his + 1 * CH_DT_BLK() + 1 * CH_RF_BLK());
+                }
+                if (w_len > 2) {
+                    xmm10 = _mm_loadu_ps(l_his + 2 * CH_DT_BLK() + 0 * CH_RF_BLK());
+                    xmm11 = _mm_loadu_ps(l_his + 2 * CH_DT_BLK() + 1 * CH_RF_BLK());
+                }
+            }
+        }
+
+        if (kernel_flags & KERNEL_FLAG_AD_BIAS()) {
+            const float* bias = PICK_PARAM(const float*, priv_param, BIAS_IDX());
+            if (oc_len > 0 * CH_DT_BLK()) {
+                xmm12 = _mm_loadu_ps(bias + 0 * CH_DT_BLK() + 0 * CH_RF_BLK());
+                xmm13 = _mm_loadu_ps(bias + 0 * CH_DT_BLK() + 1 * CH_RF_BLK());
+                if (w_len > 0) {
+                    xmm0 = _mm_add_ps(xmm0, xmm12);
+                    xmm1 = _mm_add_ps(xmm1, xmm13);
+                }
+                if (w_len > 1) {
+                    xmm2 = _mm_add_ps(xmm2, xmm12);
+                    xmm3 = _mm_add_ps(xmm3, xmm13);
+                }
+                if (w_len > 2) {
+                    xmm4 = _mm_add_ps(xmm4, xmm12);
+                    xmm5 = _mm_add_ps(xmm5, xmm13);
+                }
+            }
+            if (oc_len > 1 * CH_DT_BLK()) {
+                xmm14 = _mm_loadu_ps(bias + 1 * CH_DT_BLK() + 0 * CH_RF_BLK());
+                xmm15 = _mm_loadu_ps(bias + 1 * CH_DT_BLK() + 1 * CH_RF_BLK());
+                if (w_len > 0) {
+                    xmm6 = _mm_add_ps(xmm6, xmm14);
+                    xmm7 = _mm_add_ps(xmm7, xmm15);
+                }
+                if (w_len > 1) {
+                    xmm8 = _mm_add_ps(xmm8, xmm14);
+                    xmm9 = _mm_add_ps(xmm9, xmm15);
+                }
+                if (w_len > 2) {
+                    xmm10 = _mm_add_ps(xmm10, xmm14);
+                    xmm11 = _mm_add_ps(xmm11, xmm15);
+                }
+            }
+        }
+        
+        const float *icb_src = src + kh_start * (src_dh_stride + kernel_w * src_dw_stride);
+        const float *icb_flt = PICK_PARAM(const float*, priv_param, FLT_IDX()) + kh_start * kernel_w * CH_DT_BLK() * CH_DT_BLK();
+        int64_t channels     = shar_param[CHANNELS_IDX()];
+        while (channels >= CH_DT_BLK()) {
+            channels -= CH_DT_BLK();
+            const float *k_src = icb_src;
+            const float *k_flt_o8 = icb_flt + 0 * flt_ocb_stride;
+            const float *k_flt_o16 = icb_flt + 1 * flt_ocb_stride;
+            for (int64_t kh = kh_start; kh < kh_end; ++kh) {
+                for (int64_t kw = 0; kw < kernel_w; ++kw) {
+                    const float *ic_src = k_src;
+                    const float *ic_flt_o8 = k_flt_o8;
+                    const float *ic_flt_o16 = k_flt_o16;
+                    for (int64_t ic = 0; ic < CH_DT_BLK(); ++ic) {
+                        IC_COMPUTE_STEP(0);
+                        IC_PREFETCH_STEP(0);
+                        ic_src += 1;
+                        ic_flt_o8 += CH_DT_BLK();
+                        ic_flt_o16 += CH_DT_BLK();
+                    }
+                    k_flt_o8 += CH_DT_BLK() * CH_DT_BLK();
+                    k_flt_o16 += CH_DT_BLK() * CH_DT_BLK();
+                    k_src += src_dw_stride;
+                }
+                k_src += src_dh_stride;
+            }
+            icb_flt += kernel_h * kernel_w * CH_DT_BLK() * CH_DT_BLK();
+            icb_src += src_icb_stride;
+        }
+        if (channels > 0) {
+            const float *k_src = icb_src;
+            const float *k_flt_o8 = icb_flt + 0 * flt_ocb_stride;
+            const float *k_flt_o16 = icb_flt + 1 * flt_ocb_stride;
+            for (int64_t kh = kh_start; kh < kh_end; ++kh) {
+                for (int64_t kw = 0; kw < kernel_w; ++kw) {
+                    const float *ic_src = k_src;
+                    const float *ic_flt_o8 = k_flt_o8;
+                    const float *ic_flt_o16 = k_flt_o16;
+                    for (int64_t ic = 0; ic < channels; ++ic) {
+                        IC_COMPUTE_STEP(0);
+                        ic_src += 1;
+                        ic_flt_o8 += CH_DT_BLK();
+                        ic_flt_o16 += CH_DT_BLK();
+                    }
+                    k_flt_o8 += CH_DT_BLK() * CH_DT_BLK();
+                    k_flt_o16 += CH_DT_BLK() * CH_DT_BLK();
+                    k_src += src_dw_stride;
+                }
+                k_src += src_dh_stride;
+            }
+        }
+        
+        if (kernel_flags & (KERNEL_FLAG_RELU() | KERNEL_FLAG_RELU6())) {
+            xmm12 = _mm_setzero_ps();
+            if (oc_len > 0 * CH_DT_BLK()) {
+                if (w_len > 0) {
+                    xmm0 = _mm_max_ps(xmm0, xmm12);
+                    xmm1 = _mm_max_ps(xmm1, xmm12);
+                }
+                if (w_len > 1) {
+                    xmm2 = _mm_max_ps(xmm2, xmm12);
+                    xmm3 = _mm_max_ps(xmm3, xmm12);
+                }
+                if (w_len > 2) {
+                    xmm4 = _mm_max_ps(xmm4, xmm12);
+                    xmm5 = _mm_max_ps(xmm5, xmm12);
+                }
+            }
+            if (oc_len > 1 * CH_DT_BLK()) {
+                if (w_len > 0) {
+                    xmm6 = _mm_max_ps(xmm6, xmm12);
+                    xmm7 = _mm_max_ps(xmm7, xmm12);
+                }
+                if (w_len > 1) {
+                    xmm8 = _mm_max_ps(xmm8, xmm12);
+                    xmm9 = _mm_max_ps(xmm9, xmm12);
+                }
+                if (w_len > 2) {
+                    xmm10 = _mm_max_ps(xmm10, xmm12);
+                    xmm11 = _mm_max_ps(xmm11, xmm12);
+                }
+            }
+        }
+        if (kernel_flags & KERNEL_FLAG_RELU6()) {
+            xmm13 = _mm_set1_ps(6.0f);
+            if (oc_len > 0 * CH_DT_BLK()) {
+                if (w_len > 0) {
+                    xmm0 = _mm_min_ps(xmm0, xmm13);
+                    xmm1 = _mm_min_ps(xmm1, xmm13);
+                }
+                if (w_len > 1) {
+                    xmm2 = _mm_min_ps(xmm2, xmm13);
+                    xmm3 = _mm_min_ps(xmm3, xmm13);
+                }
+                if (w_len > 2) {
+                    xmm4 = _mm_min_ps(xmm4, xmm13);
+                    xmm5 = _mm_min_ps(xmm5, xmm13);
+                }
+            }
+            if (oc_len > 1 * CH_DT_BLK()) {
+                if (w_len > 0) {
+                    xmm6 = _mm_min_ps(xmm6, xmm13);
+                    xmm7 = _mm_min_ps(xmm7, xmm13);
+                }
+                if (w_len > 1) {
+                    xmm8 = _mm_min_ps(xmm8, xmm13);
+                    xmm9 = _mm_min_ps(xmm9, xmm13);
+                }
+                if (w_len > 2) {
+                    xmm10 = _mm_min_ps(xmm10, xmm13);
+                    xmm11 = _mm_min_ps(xmm11, xmm13);
+                }
+            }
+        }
+
+        if (nt_store) {
+            float* l_dst = dst;
+            const int64_t dst_ocb_stride = shar_param[DST_OCB_STRIDE_IDX()];
+            if (oc_len > 0 * CH_DT_BLK()) {
+                if (w_len > 0) {
+                    _mm_stream_ps(l_dst + 0 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm0);
+                    _mm_stream_ps(l_dst + 0 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm1);
+                }
+                if (w_len > 1) {
+                    _mm_stream_ps(l_dst + 1 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm2);
+                    _mm_stream_ps(l_dst + 1 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm3);
+                }
+                if (w_len > 2) {
+                    _mm_stream_ps(l_dst + 2 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm4);
+                    _mm_stream_ps(l_dst + 2 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm5);
+                }
+            }
+            if (oc_len > 1 * CH_DT_BLK()) {
+                l_dst += dst_ocb_stride;
+                if (w_len > 0) {
+                    _mm_stream_ps(l_dst + 0 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm6);
+                    _mm_stream_ps(l_dst + 0 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm7);
+                }
+                if (w_len > 1) {
+                    _mm_stream_ps(l_dst + 1 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm8);
+                    _mm_stream_ps(l_dst + 1 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm9);
+                }
+                if (w_len > 2) {
+                    _mm_stream_ps(l_dst + 2 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm10);
+                    _mm_stream_ps(l_dst + 2 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm11);
+                }
+            }
+        } else {
+            float* l_dst = dst;
+            const int64_t dst_ocb_stride = shar_param[DST_OCB_STRIDE_IDX()];
+            if (oc_len > 0 * CH_DT_BLK()) {
+                if (w_len > 0) {
+                    _mm_storeu_ps(l_dst + 0 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm0);
+                    _mm_storeu_ps(l_dst + 0 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm1);
+                }
+                if (w_len > 1) {
+                    _mm_storeu_ps(l_dst + 1 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm2);
+                    _mm_storeu_ps(l_dst + 1 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm3);
+                }
+                if (w_len > 2) {
+                    _mm_storeu_ps(l_dst + 2 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm4);
+                    _mm_storeu_ps(l_dst + 2 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm5);
+                }
+            }
+            if (oc_len > 1 * CH_DT_BLK()) {
+                l_dst += dst_ocb_stride;
+                if (w_len > 0) {
+                    _mm_storeu_ps(l_dst + 0 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm6);
+                    _mm_storeu_ps(l_dst + 0 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm7);
+                }
+                if (w_len > 1) {
+                    _mm_storeu_ps(l_dst + 1 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm8);
+                    _mm_storeu_ps(l_dst + 1 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm9);
+                }
+                if (w_len > 2) {
+                    _mm_storeu_ps(l_dst + 2 * CH_DT_BLK() + 0 * CH_RF_BLK(), xmm10);
+                    _mm_storeu_ps(l_dst + 2 * CH_DT_BLK() + 1 * CH_RF_BLK(), xmm11);
+                }
+            }
+        }
+        src += w_len * src_sw_stride;
+        his += w_len * CH_DT_BLK();
+        dst += w_len * CH_DT_BLK();
+        ow -= w_len;
+    } while (ow > 0);
+    PICK_PARAM(const float *, priv_param, SRC_IDX()) = src;
+    PICK_PARAM(const float *, priv_param, HIS_IDX()) = his;
+    PICK_PARAM(float *, priv_param, DST_IDX()) = dst;
+#undef IC_COMPUTE_STEP
+#undef IC_PREFETCH_STEP
+}
+
+}}};
+
+#endif

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_fp32_sse.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_fp32_sse.cpp
@@ -1,0 +1,429 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <new>
+#include <nmmintrin.h>
+#include <string.h>
+
+#include "ppl/kernel/x86/fp32/reorder.h"
+#include "ppl/kernel/x86/common/sse_tools.h"
+#include "ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_fp32_sse.h"
+#include "ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_kernel_fp32_sse.h"
+#include "ppl/common/sys.h"
+
+#define ASSUME_L2_BYTES() (256 * 1024)
+#define ASSUME_L2_WAYS()  4
+#define ASSUME_L3_BYTES() (2048 * 1024)
+#define L2_RATIO()        0.251
+#define L3_RATIO()        0.501
+
+#define IC_L2_BLK_MAX()        (16 * CH_DT_BLK())
+#define IC_L2_BLK_TAIL_RATIO() 0.334
+
+#define PADDING_POLICY_NOPAD() 0
+#define PADDING_POLICY_PREPAD() 1
+
+namespace ppl { namespace kernel { namespace x86 {
+
+int32_t conv2d_n8cx_direct_fp32_sse_executor::cal_ic_l2_blk(const conv2d_fp32_param &param)
+{
+    const int32_t ic_per_gp = param.channels / param.group;
+    const int32_t padded_ic = round_up(ic_per_gp, CH_DT_BLK());
+
+    int32_t ic_l2_blk;
+    if (padded_ic >= IC_L2_BLK_MAX()) {
+        ic_l2_blk = min(div_up(4 * IC_L2_BLK_MAX(), param.kernel_h * param.kernel_w * CH_DT_BLK()) * CH_DT_BLK(), padded_ic);
+    } else {
+        ic_l2_blk = min(div_up(IC_L2_BLK_MAX(), param.kernel_h * param.kernel_w * CH_DT_BLK()) * CH_DT_BLK(), padded_ic);
+    }
+    if (mod_up(padded_ic, ic_l2_blk) < IC_L2_BLK_TAIL_RATIO() * ic_l2_blk) {
+        ic_l2_blk = round_up(padded_ic / (padded_ic / ic_l2_blk), CH_DT_BLK());
+    }
+    return ic_l2_blk;
+}
+
+void conv2d_n8cx_direct_fp32_sse_executor::init_preproc_param()
+{
+    schedule_param_.ic_per_gp = conv_param_->channels / conv_param_->group;
+    schedule_param_.oc_per_gp = conv_param_->num_output / conv_param_->group;
+    schedule_param_.padded_ic = round_up(schedule_param_.ic_per_gp, CH_DT_BLK());
+    schedule_param_.padded_oc = round_up(schedule_param_.oc_per_gp, CH_DT_BLK());
+}
+
+void conv2d_n8cx_direct_fp32_sse_executor::cal_kernel_tunning_param()
+{
+    const conv2d_fp32_param &cp = *conv_param_;
+    kernel_schedule_param &sp   = schedule_param_;
+
+    const int32_t num_thread   = PPL_OMP_MAX_THREADS();
+    const int32_t batch        = src_shape_->GetDim(0);
+    const int32_t src_h        = src_shape_->GetDim(2);
+    const int32_t src_w        = src_shape_->GetDim(3);
+    const int32_t dst_h        = dst_shape_->GetDim(2);
+    const int32_t dst_w        = dst_shape_->GetDim(3);
+    const int32_t ext_kernel_w = (cp.kernel_w - 1) * cp.dilation_w + 1;
+
+    const float l3_cap_all_core = (ppl::common::GetCpuCacheL3() == 0 ? (ASSUME_L3_BYTES() * num_thread) : ppl::common::GetCpuCacheL3()) * L3_RATIO() / sizeof(float);
+
+    sp.ic_l2_blk = cal_ic_l2_blk(cp);
+    sp.ic_l2_cnt = div_up(sp.padded_ic, sp.ic_l2_blk);
+
+    sp.gp_l3_blk = min<int32_t>(cp.group, num_thread);
+    sp.mb_l3_blk = min<int32_t>(batch, div_up(num_thread, sp.gp_l3_blk));
+    const int64_t padded_src_hw = int64_t(src_h) * (src_w + 2 * cp.pad_w);
+    while (sp.gp_l3_blk > 1 && sp.gp_l3_blk * sp.mb_l3_blk * sp.ic_l2_blk * padded_src_hw > l3_cap_all_core) {
+        --sp.gp_l3_blk;
+    }
+    sp.mb_l3_blk = min<int32_t>(batch, div_up(num_thread, sp.gp_l3_blk));
+    while (sp.mb_l3_blk > 1 && sp.gp_l3_blk * sp.mb_l3_blk * sp.ic_l2_blk * padded_src_hw > l3_cap_all_core) {
+        --sp.mb_l3_blk;
+    }
+
+    sp.padding_policy = PADDING_POLICY_NOPAD();
+
+    sp.unroll_ow_start = -1;
+    sp.unroll_ow_end = -1;
+    if (sp.padding_policy == PADDING_POLICY_NOPAD()) {
+        for (int32_t ow = 0; ow < dst_w; ++ow) {
+            if (ow * cp.stride_w - cp.pad_w >= 0) {
+                sp.unroll_ow_start = ow;
+                break;
+            }
+        }
+        for (int32_t ow = dst_w - 1; ow >= 0; --ow) {
+            if (ow * cp.stride_w - cp.pad_w + ext_kernel_w <= src_w) {
+                sp.unroll_ow_end = ow + 1;
+                break;
+            }
+        }
+        if (sp.unroll_ow_start >= sp.unroll_ow_end || sp.unroll_ow_start < 0 || sp.unroll_ow_end < 0) {
+            sp.unroll_ow_start = sp.unroll_ow_end = dst_w;
+        }
+    } else {
+        sp.unroll_ow_start = 0;
+        sp.unroll_ow_end = dst_w;
+    }
+
+    sp.ow_kr_blk = BLK1X3_OW_RF();
+    sp.oc_kr_blk = BLK1X3_OC_RF() * CH_RF_BLK();
+    sp.oc_l2_blk = 4 * CH_DT_BLK();
+
+    sp.use_nt_store = 0;
+    if (batch * cp.group * sp.padded_oc * dst_h * dst_w > l3_cap_all_core * 2) {
+        sp.use_nt_store = 1;
+    }
+}
+
+uint64_t conv2d_n8cx_direct_fp32_sse_executor::cal_temp_buffer_size()
+{
+    if (schedule_param_.padding_policy == PADDING_POLICY_PREPAD()) {
+        const int32_t src_h          = src_shape_->GetDim(2);
+        const int32_t src_w          = src_shape_->GetDim(3);
+        const uint64_t padded_src_hw = uint64_t(src_h) * (src_w + 2 * conv_param_->pad_w);
+        return padded_src_hw * schedule_param_.mb_l3_blk * schedule_param_.gp_l3_blk * schedule_param_.ic_l2_blk * sizeof(float);
+    }
+    return 64u;
+}
+
+ppl::common::RetCode conv2d_n8cx_direct_fp32_sse_executor::prepare()
+{
+    if (!conv_param_ || !src_shape_ || !dst_shape_ || ((conv_param_->fuse_flag & conv_fuse_flag::sum) && !sum_src_shape_)) {
+        return ppl::common::RC_INVALID_VALUE;
+    }
+
+    init_preproc_param();
+    cal_kernel_tunning_param();
+
+    return ppl::common::RC_SUCCESS;
+}
+
+ppl::common::RetCode conv2d_n8cx_direct_fp32_sse_executor::execute()
+{
+    if (!conv_param_ || !cvt_filter_ || !cvt_bias_ || !src_ || !dst_ || ((conv_param_->fuse_flag & conv_fuse_flag::sum) && !sum_src_) || !temp_buffer_) {
+        return ppl::common::RC_INVALID_VALUE;
+    }
+
+    const conv2d_fp32_param &cp     = *conv_param_;
+    const kernel_schedule_param &sp = schedule_param_;
+
+    const int32_t batch = src_shape_->GetDim(0);
+    const int32_t src_h = src_shape_->GetDim(2);
+    const int32_t src_w = src_shape_->GetDim(3);
+    const int32_t dst_h = dst_shape_->GetDim(2);
+    const int32_t dst_w = dst_shape_->GetDim(3);
+
+    const int32_t ext_kernel_h = (cp.kernel_h - 1) * cp.dilation_h + 1;
+    const int32_t ext_kernel_w = (cp.kernel_w - 1) * cp.dilation_w + 1;
+
+    const int64_t src_b_stride   = int64_t(round_up(src_shape_->GetDim(1), CH_DT_BLK())) * src_h * src_w;
+    const int64_t src_g_stride   = int64_t(sp.padded_ic) * src_h * src_w;
+    const int64_t src_icb_stride = int64_t(src_h) * src_w * CH_DT_BLK();
+    const int64_t src_h_stride   = int64_t(src_w) * CH_DT_BLK();
+    const int64_t src_sw_stride  = int64_t(cp.stride_w) * CH_DT_BLK();
+    const int64_t src_dh_stride  = int64_t(cp.dilation_h) * src_w * CH_DT_BLK();
+    const int64_t src_dw_stride  = int64_t(cp.dilation_w) * CH_DT_BLK();
+    const int64_t dst_b_stride   = int64_t(round_up(dst_shape_->GetDim(1), CH_DT_BLK())) * dst_h * dst_w;
+    const int64_t dst_g_stride   = int64_t(sp.padded_oc) * dst_h * dst_w;
+    const int64_t dst_ocb_stride = int64_t(dst_h) * dst_w * CH_DT_BLK();
+    const int64_t dst_h_stride   = int64_t(dst_w) * CH_DT_BLK();
+    const int64_t flt_g_stride   = int64_t(sp.ic_l2_cnt) * sp.padded_oc * cp.kernel_h * cp.kernel_w * sp.ic_l2_blk;
+    const int64_t flt_ocb_stride = int64_t(sp.ic_l2_blk) * cp.kernel_h * cp.kernel_w * CH_DT_BLK();
+
+    const bool with_sum   = cp.fuse_flag & conv_fuse_flag::sum;
+    const bool with_relu  = cp.fuse_flag & conv_fuse_flag::relu;
+    const bool with_relu6 = cp.fuse_flag & conv_fuse_flag::relu6;
+
+    int64_t sum_src_b_stride = 0;
+    if (with_sum) {
+        sum_src_b_stride = int64_t(round_up(sum_src_shape_->GetDim(1), CH_DT_BLK())) * dst_h * dst_w;
+    }
+
+    int64_t share_param[SHAR_PARAM_LEN()];
+    share_param[KH_IDX()] = cp.kernel_h;
+    share_param[KW_IDX()] = cp.kernel_w;
+    share_param[HIS_OCB_STRIDE_IDX()] = dst_ocb_stride;
+    share_param[DST_OCB_STRIDE_IDX()] = dst_ocb_stride;
+    share_param[FLT_OCB_STRIDE_IDX()] = flt_ocb_stride;
+    const int64_t nt_store_sel = sp.use_nt_store;
+    const int64_t stride_w_sel = cp.stride_w > 2 ? 0 : cp.stride_w;
+    for (int64_t mbl3 = 0; mbl3 < batch; mbl3 += sp.mb_l3_blk) {
+        const int64_t mbl3_eff = min<int64_t>(batch - mbl3, sp.mb_l3_blk);
+        for (int64_t gpl3 = 0; gpl3 < cp.group; gpl3 += sp.gp_l3_blk) {
+            const int64_t gpl3_eff = min<int64_t>(cp.group - gpl3, sp.gp_l3_blk);
+            for (int64_t icl2 = 0; icl2 < sp.padded_ic; icl2 += sp.ic_l2_blk) {
+                const int64_t icl2_eff = min<int64_t>(sp.ic_per_gp - icl2, sp.ic_l2_blk);
+                const bool is_first_ic = icl2 == 0;
+                const bool is_last_ic  = (icl2 + sp.ic_l2_blk >= sp.ic_per_gp);
+                const float *base_src = src_;
+                const float *base_his = dst_;
+                const float *base_flt = cvt_filter_;
+                float *base_dst       = dst_;
+
+                int64_t base_src_b_stride   = src_b_stride;
+                int64_t base_src_g_stride   = src_g_stride;
+                int64_t base_src_icb_stride = src_icb_stride;
+                int64_t base_src_h_stride   = src_h_stride;
+                int64_t base_src_dh_stride  = src_dh_stride;
+                int64_t his_b_stride        = dst_b_stride;
+                uint64_t kernel_flags = 0;
+                if (is_first_ic) {
+                    if (with_sum) {
+                        base_his     = sum_src_;
+                        his_b_stride = sum_src_b_stride;
+                        kernel_flags |= KERNEL_FLAG_AD_BIAS();
+                    } else {
+                        kernel_flags |= KERNEL_FLAG_LD_BIAS();
+                    }
+                }
+                if (is_last_ic) {
+                    if (with_relu) {
+                        kernel_flags |= KERNEL_FLAG_RELU();
+                    } else if (with_relu6) {
+                        kernel_flags |= KERNEL_FLAG_RELU6();
+                    }
+                }
+                base_src += mbl3 * base_src_b_stride + gpl3 * base_src_g_stride + icl2 * src_h * src_w;
+                base_dst += mbl3 * dst_b_stride + gpl3 * dst_g_stride;
+                base_his += mbl3 * his_b_stride + gpl3 * dst_g_stride;
+                base_flt += gpl3 * flt_g_stride + icl2 * sp.padded_oc * cp.kernel_h * cp.kernel_w;
+
+                if (sp.padding_policy == PADDING_POLICY_PREPAD()) {
+                    const int64_t src_trans_w          = src_w + 2 * cp.pad_w;
+                    const int64_t src_trans_b_stride   = int64_t(sp.ic_l2_blk) * src_h * src_trans_w;
+                    const int64_t src_trans_g_stride   = int64_t(sp.mb_l3_blk) * sp.ic_l2_blk * src_h * src_trans_w;
+                    const int64_t src_trans_icb_stride = int64_t(src_h) * src_trans_w * CH_DT_BLK();
+                    const int64_t src_trans_h_stride   = int64_t(src_trans_w) * CH_DT_BLK();
+                    const int64_t src_trans_dh_stride  = int64_t(cp.dilation_h) * src_trans_w * CH_DT_BLK();
+                    float *src_trans = reinterpret_cast<float*>(temp_buffer_);
+#ifdef PPL_USE_X86_OMP_COLLAPSE
+                    PRAGMA_OMP_PARALLEL_FOR_COLLAPSE(3)
+#endif
+                    for (int64_t g = 0; g < gpl3_eff; ++g) {
+#ifndef PPL_USE_X86_OMP_COLLAPSE
+                        PRAGMA_OMP_PARALLEL_FOR()
+#endif
+                        for (int64_t b = 0; b < mbl3_eff; ++b) {
+                            for (int64_t icb = 0; icb < div_up(icl2_eff, CH_DT_BLK()); ++icb) {
+                                const float *l_base_src = base_src + g * base_src_g_stride + b * base_src_b_stride + icb * base_src_icb_stride;
+                                float *l_src_trans      = src_trans + g * src_trans_g_stride + b * src_trans_b_stride + icb * src_trans_icb_stride;
+                                for (int64_t ih = 0; ih < src_h; ++ih) {
+                                    memset32_sse(l_src_trans, 0, cp.pad_w * CH_DT_BLK());
+                                    l_src_trans += cp.pad_w * CH_DT_BLK();
+                                    memcpy32_sse(l_src_trans, l_base_src, src_h_stride);
+                                    l_src_trans += src_h_stride;
+                                    l_base_src += src_h_stride;
+                                    memset32_sse(l_src_trans, 0, cp.pad_w * CH_DT_BLK());
+                                    l_src_trans += cp.pad_w * CH_DT_BLK();
+                                }
+                            }
+                        }
+                    }
+                    base_src            = src_trans + cp.pad_w * CH_DT_BLK();
+                    base_src_b_stride   = src_trans_b_stride;
+                    base_src_g_stride   = src_trans_g_stride;
+                    base_src_icb_stride = src_trans_icb_stride;
+                    base_src_h_stride   = src_trans_h_stride;
+                    base_src_dh_stride  = src_trans_dh_stride;
+                }
+                share_param[SRC_ICB_STRIDE_IDX()] = base_src_icb_stride;
+                share_param[SRC_SW_STRIDE_IDX()] = src_sw_stride;
+                share_param[SRC_DH_STRIDE_IDX()] = base_src_dh_stride;
+                share_param[SRC_DW_STRIDE_IDX()] = src_dw_stride;
+                share_param[CHANNELS_IDX()] = icl2_eff;
+                PICK_PARAM(uint64_t, share_param, FLAGS_IDX()) = kernel_flags;
+#ifdef PPL_USE_X86_OMP_COLLAPSE
+                PRAGMA_OMP_PARALLEL_FOR_COLLAPSE(4)
+#endif
+                for (int64_t g = 0; g < gpl3_eff; ++g) {
+                    for (int64_t b = 0; b < mbl3_eff; ++b) {
+#ifndef PPL_USE_X86_OMP_COLLAPSE
+                        PRAGMA_OMP_PARALLEL_FOR()
+#endif
+                        for (int64_t ocl2 = 0; ocl2 < sp.padded_oc; ocl2 += sp.oc_l2_blk) {
+                            for (int64_t oh = 0; oh < dst_h; ++oh) {
+                                int64_t private_param[PRIV_PARAM_LEN()];
+                                const int64_t ocl2_eff = min<int64_t>(sp.padded_oc - ocl2, sp.oc_l2_blk);
+                                const int64_t ih       = oh * cp.stride_h - cp.pad_h;
+                                private_param[KH_START_IDX()] = div_up(min<int64_t>(max<int64_t>(0 - ih, 0), ext_kernel_h - 1), cp.dilation_h);
+                                private_param[KH_END_IDX()]   = div_up(max<int64_t>(min<int64_t>(src_h - ih, ext_kernel_h), 0), cp.dilation_h);
+                                const int64_t ow_unroll_len  = sp.unroll_ow_end - sp.unroll_ow_start;
+                                const int64_t ow_unroll_body = round(ow_unroll_len, sp.ow_kr_blk);
+                                const int64_t ow_unroll_tail = ow_unroll_len - ow_unroll_body;
+                                const float *l_src  = base_src + b * base_src_b_stride + g * base_src_g_stride + ih * base_src_h_stride - cp.pad_w * CH_DT_BLK();
+                                const float *l_his  = base_his + b * his_b_stride + g * dst_g_stride + ocl2 * dst_h * dst_w + oh * dst_h_stride;
+                                float *l_dst        = base_dst + b * dst_b_stride + g * dst_g_stride + ocl2 * dst_h * dst_w + oh * dst_h_stride;
+                                const float *l_flt  = base_flt + g * flt_g_stride + ocl2 * sp.ic_l2_blk * cp.kernel_h * cp.kernel_w;
+                                const float *l_bias = cvt_bias_ + (g + gpl3) * sp.padded_oc + ocl2;
+                                for (int64_t oc = ocl2; oc < ocl2 + ocl2_eff; oc += sp.oc_kr_blk) {
+                                    const int64_t oc_eff = min<int64_t>(ocl2 + ocl2_eff - oc, sp.oc_kr_blk);
+                                    const int64_t oc_sel = div_up(oc_eff, CH_DT_BLK()) - 1;
+
+                                    PICK_PARAM(const float *, private_param, SRC_IDX())  = l_src;
+                                    PICK_PARAM(const float *, private_param, HIS_IDX())  = l_his;
+                                    PICK_PARAM(float *, private_param, DST_IDX())        = l_dst;
+                                    PICK_PARAM(const float *, private_param, FLT_IDX())  = l_flt;
+                                    PICK_PARAM(const float *, private_param, BIAS_IDX()) = l_bias;
+
+                                    for (int64_t ow = 0; ow < sp.unroll_ow_start; ++ow) {
+                                        const int64_t iw = ow * cp.stride_w - cp.pad_w;
+                                        if (cp.dilation_w == 1) {
+                                            private_param[KW_START_IDX()] = min<int64_t>(max<int64_t>(0 - iw, 0), ext_kernel_w - 1);
+                                            private_param[KW_END_IDX()]   = max<int64_t>(min<int64_t>(src_w - iw, ext_kernel_w), 0);
+                                        } else {
+                                            private_param[KW_START_IDX()] = div_up(min<int64_t>(max<int64_t>(0 - iw, 0), ext_kernel_w - 1), cp.dilation_w);
+                                            private_param[KW_END_IDX()]   = div_up(max<int64_t>(min<int64_t>(src_w - iw, ext_kernel_w), 0), cp.dilation_w);
+                                        }
+                                        conv2d_n8cx_direct_kernel_fp32_sse_pad_table[nt_store_sel][oc_sel](share_param, private_param);
+                                    }
+
+                                    if (ow_unroll_body) {
+                                        private_param[OW_IDX()] = ow_unroll_body;
+                                        switch (oc_sel) {
+                                            case 0: conv2d_n8cx_direct_kernel_fp32_sse_o8_table[nt_store_sel][stride_w_sel][sp.ow_kr_blk - 1](share_param, private_param); break;
+                                            case 1: conv2d_n8cx_direct_kernel_fp32_sse_o16_table[nt_store_sel][stride_w_sel][sp.ow_kr_blk - 1](share_param, private_param); break;
+                                            
+                                        }
+                                    }
+                                    if (ow_unroll_tail) {
+                                        private_param[OW_IDX()] = ow_unroll_tail;
+                                        switch (oc_sel) {
+                                            case 0: conv2d_n8cx_direct_kernel_fp32_sse_o8_table[nt_store_sel][stride_w_sel][ow_unroll_tail - 1](share_param, private_param); break;
+                                            case 1: conv2d_n8cx_direct_kernel_fp32_sse_o16_table[nt_store_sel][stride_w_sel][ow_unroll_tail - 1](share_param, private_param); break;
+                                        }
+                                    }
+
+                                    for (int64_t ow = sp.unroll_ow_end; ow < dst_w; ++ow) {
+                                        const int64_t iw = ow * cp.stride_w - cp.pad_w;
+                                        if (cp.dilation_w == 1) {
+                                            private_param[KW_START_IDX()] = min<int64_t>(max<int64_t>(0 - iw, 0), ext_kernel_w - 1);
+                                            private_param[KW_END_IDX()]   = max<int64_t>(min<int64_t>(src_w - iw, ext_kernel_w), 0);
+                                        } else {
+                                            private_param[KW_START_IDX()] = div_up(min<int64_t>(max<int64_t>(0 - iw, 0), ext_kernel_w - 1), cp.dilation_w);
+                                            private_param[KW_END_IDX()]   = div_up(max<int64_t>(min<int64_t>(src_w - iw, ext_kernel_w), 0), cp.dilation_w);
+                                        }
+                                        conv2d_n8cx_direct_kernel_fp32_sse_pad_table[nt_store_sel][oc_sel](share_param, private_param);
+                                    }
+                                    l_bias += sp.oc_kr_blk;
+                                    l_flt  += sp.oc_kr_blk * sp.ic_l2_blk * cp.kernel_h * cp.kernel_w;
+                                    l_dst  += sp.oc_kr_blk * dst_h * dst_w;
+                                    l_his  += sp.oc_kr_blk * dst_h * dst_w;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (sp.use_nt_store) {
+                PRAGMA_OMP_PARALLEL()
+                {
+                    _mm_sfence();
+                }
+            }
+        }
+    }
+
+    return ppl::common::RC_SUCCESS;
+}
+
+ppl::common::RetCode conv2d_n8cx_direct_fp32_sse_manager::gen_cvt_weights(const float *filter, const float *bias)
+{
+    if (cvt_bias_ != nullptr || cvt_filter_ != nullptr) {
+        return ppl::common::RC_PERMISSION_DENIED;
+    }
+
+    const int32_t oc_per_gp = param_.num_output / param_.group;
+    const int32_t padded_oc = round_up(oc_per_gp, CH_DT_BLK());
+    const int32_t ic_l2_blk = conv2d_n8cx_direct_fp32_sse_executor::cal_ic_l2_blk(param_);
+
+    cvt_bias_size_ = param_.group * padded_oc;
+    cvt_bias_      = (float *)allocator_->Alloc(cvt_bias_size_ * sizeof(float));
+    if (cvt_bias_ == nullptr) {
+        return ppl::common::RC_OUT_OF_MEMORY;
+    }
+
+    for (int32_t g = 0; g < param_.group; ++g) {
+        memcpy(cvt_bias_ + g * padded_oc, bias + g * oc_per_gp, oc_per_gp * sizeof(float));
+        memset(cvt_bias_ + g * padded_oc + oc_per_gp, 0, (padded_oc - oc_per_gp) * sizeof(float));
+    }
+
+    cvt_filter_size_ = reorder_goidhw_gIOBidhw8i8o_fp32_get_dst_size(
+        param_.group, param_.num_output, param_.channels,
+        1, param_.kernel_h, param_.kernel_w, ic_l2_blk);
+    cvt_filter_size_ /= sizeof(float);
+    cvt_filter_      = (float *)allocator_->Alloc(cvt_filter_size_ * sizeof(float));
+    if (cvt_filter_ == nullptr) {
+        return ppl::common::RC_OUT_OF_MEMORY;
+    }
+
+    return reorder_goidhw_gIOBidhw8i8o_fp32(
+        filter, param_.group, param_.num_output, param_.channels,
+        1, param_.kernel_h, param_.kernel_w, ic_l2_blk, cvt_filter_);
+}
+
+bool conv2d_n8cx_direct_fp32_sse_manager::is_supported()
+{
+    bool aligned_channels   = param_.channels / param_.group % CH_DT_BLK() == 0;
+    bool aligned_num_output = param_.num_output / param_.group % CH_DT_BLK() == 0;
+    return (param_.group == 1) || (aligned_channels && aligned_num_output);
+}
+
+conv2d_fp32_executor *conv2d_n8cx_direct_fp32_sse_manager::gen_executor()
+{
+    return new conv2d_n8cx_direct_fp32_sse_executor(&param_, cvt_filter_, cvt_bias_);
+}
+
+}}}; // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_fp32_sse.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_fp32_sse.h
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_FP32_CONV2D_DIRECT_SSE_CONV2D_N8CX_DIRECT_FP32_SSE_H_
+#define __ST_PPL_KERNEL_X86_FP32_CONV2D_DIRECT_SSE_CONV2D_N8CX_DIRECT_FP32_SSE_H_
+
+#include "ppl/kernel/x86/fp32/conv2d.h"
+#include "ppl/kernel/x86/common/internal_include.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+// forward declare;
+class conv2d_n8cx_direct_fp32_sse_manager;
+
+class conv2d_n8cx_direct_fp32_sse_executor final : public conv2d_fp32_executor {
+public:
+    conv2d_n8cx_direct_fp32_sse_executor() {}
+    conv2d_n8cx_direct_fp32_sse_executor(const conv2d_fp32_param *conv_param, const float *cvt_filter, const float *bias)
+        : conv2d_fp32_executor(conv_param, cvt_filter, bias) {}
+    uint64_t cal_temp_buffer_size() override;
+    ppl::common::RetCode prepare() override;
+    ppl::common::RetCode execute() override;
+
+private:
+    struct kernel_schedule_param {
+        // Preprocessed param
+        int32_t ic_per_gp;
+        int32_t oc_per_gp;
+        int32_t padded_ic;
+        int32_t padded_oc;
+
+        // Kernel tunning
+        int32_t ow_kr_blk;
+        int32_t ic_l2_blk;
+        int32_t ic_l2_cnt;
+        int32_t oc_kr_blk;
+        int32_t oc_l2_blk;
+        int32_t mb_l3_blk;
+        int32_t gp_l3_blk;
+        int32_t use_nt_store;
+        int32_t unroll_ow_start;
+        int32_t unroll_ow_end;
+        int32_t padding_policy;
+    } schedule_param_;
+
+    void init_preproc_param();
+    void cal_kernel_tunning_param();
+
+    static int32_t cal_ic_l2_blk(const conv2d_fp32_param &param);
+
+    friend conv2d_n8cx_direct_fp32_sse_manager;
+};
+
+class conv2d_n8cx_direct_fp32_sse_manager final : public conv2d_fp32_manager {
+public:
+    conv2d_n8cx_direct_fp32_sse_manager() {}
+    conv2d_n8cx_direct_fp32_sse_manager(const conv2d_fp32_param &param, ppl::common::Allocator *allocator)
+        : conv2d_fp32_manager(param, allocator) {}
+    bool is_supported() override;
+    ppl::common::RetCode gen_cvt_weights(const float *filter, const float *bias) override;
+    conv2d_fp32_executor *gen_executor() override;
+};
+
+}}}; // namespace ppl::kernel::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_kernel_fp32_sse.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_kernel_fp32_sse.cpp
@@ -1,0 +1,81 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_blk1x1_kernel_fp32_sse.h"
+#include "ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_blk1x3_kernel_fp32_sse.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+conv2d_n8cx_direct_kernel_fp32_sse_func_t
+conv2d_n8cx_direct_kernel_fp32_sse_pad_table[NT_STORE_OPT()][OCRF_BLK_OPT()] =
+{
+    {
+        conv2d_n8cx_direct_fp32_sse_blk1x1_kernel<false, 1 * CH_DT_BLK()>,
+        conv2d_n8cx_direct_fp32_sse_blk1x1_kernel<false, 2 * CH_DT_BLK()>,
+    },
+    {
+        conv2d_n8cx_direct_fp32_sse_blk1x1_kernel<true, 1 * CH_DT_BLK()>,
+        conv2d_n8cx_direct_fp32_sse_blk1x1_kernel<true, 2 * CH_DT_BLK()>,
+    },
+};
+
+#define DIRECT_O8_KERNEL_TABLE_BLK(NT_STORE, STRIDE_W) \
+    {\
+        conv2d_n8cx_direct_fp32_sse_blk1x3_kernel<NT_STORE, STRIDE_W, 1 * CH_DT_BLK(), 1>,\
+        conv2d_n8cx_direct_fp32_sse_blk1x3_kernel<NT_STORE, STRIDE_W, 1 * CH_DT_BLK(), 2>,\
+        conv2d_n8cx_direct_fp32_sse_blk1x3_kernel<NT_STORE, STRIDE_W, 1 * CH_DT_BLK(), 3>,\
+    }
+
+#define DIRECT_O16_KERNEL_TABLE_BLK(NT_STORE, STRIDE_W) \
+    {\
+        conv2d_n8cx_direct_fp32_sse_blk1x3_kernel<NT_STORE, STRIDE_W, 2 * CH_DT_BLK(), 1>,\
+        conv2d_n8cx_direct_fp32_sse_blk1x3_kernel<NT_STORE, STRIDE_W, 2 * CH_DT_BLK(), 2>,\
+        conv2d_n8cx_direct_fp32_sse_blk1x3_kernel<NT_STORE, STRIDE_W, 2 * CH_DT_BLK(), 3>,\
+    }
+
+conv2d_n8cx_direct_kernel_fp32_sse_func_t
+    conv2d_n8cx_direct_kernel_fp32_sse_o8_table[NT_STORE_OPT()][STRIDE_W_OPT()][MAX_OW_RF()] =
+{
+    {
+        DIRECT_O8_KERNEL_TABLE_BLK(false, 0),
+        DIRECT_O8_KERNEL_TABLE_BLK(false, 1),
+        DIRECT_O8_KERNEL_TABLE_BLK(false, 2),
+    },
+    {
+        DIRECT_O8_KERNEL_TABLE_BLK(true, 0),
+        DIRECT_O8_KERNEL_TABLE_BLK(true, 1),
+        DIRECT_O8_KERNEL_TABLE_BLK(true, 2),
+    },
+};
+
+conv2d_n8cx_direct_kernel_fp32_sse_func_t
+    conv2d_n8cx_direct_kernel_fp32_sse_o16_table[NT_STORE_OPT()][STRIDE_W_OPT()][MAX_OW_RF()] =
+{
+    {
+        DIRECT_O16_KERNEL_TABLE_BLK(false, 0),
+        DIRECT_O16_KERNEL_TABLE_BLK(false, 1),
+        DIRECT_O16_KERNEL_TABLE_BLK(false, 2),
+    },
+    {
+        DIRECT_O16_KERNEL_TABLE_BLK(true, 0),
+        DIRECT_O16_KERNEL_TABLE_BLK(true, 1),
+        DIRECT_O16_KERNEL_TABLE_BLK(true, 2),
+    },
+};
+
+
+}}};

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_kernel_fp32_sse.h
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct/sse/conv2d_n8cx_direct_kernel_fp32_sse.h
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_FP32_CONV2D_DIRECT_SSE_CONV2D_N8CX_DIRECT_KERNEL_FP32_SSE_H_
+#define __ST_PPL_KERNEL_X86_FP32_CONV2D_DIRECT_SSE_CONV2D_N8CX_DIRECT_KERNEL_FP32_SSE_H_
+
+#include "ppl/kernel/x86/common/internal_include.h"
+#include "ppl/kernel/x86/fp32/conv2d.h"
+
+#define KERNEL_FLAG_LD_BIAS() (1 << 0)
+#define KERNEL_FLAG_AD_BIAS() (1 << 1)
+#define KERNEL_FLAG_RELU()    (1 << 2)
+#define KERNEL_FLAG_RELU6()   (1 << 3)
+
+#define PICK_PARAM(T, PARAM, IDX) *(T*)(PARAM + IDX)
+
+#define PRIV_PARAM_LEN() 12
+#define SRC_IDX()        0
+#define HIS_IDX()        1
+#define DST_IDX()        2
+#define FLT_IDX()        3
+#define BIAS_IDX()       4
+#define OW_IDX()         5
+#define KH_START_IDX()   6
+#define KH_END_IDX()     7
+#define KW_START_IDX()   8
+#define KW_END_IDX()     9
+
+#define SHAR_PARAM_LEN()     12
+#define CHANNELS_IDX()       0
+#define SRC_ICB_STRIDE_IDX() 1
+#define SRC_SW_STRIDE_IDX()  2
+#define SRC_DH_STRIDE_IDX()  3
+#define SRC_DW_STRIDE_IDX()  4
+#define HIS_OCB_STRIDE_IDX() 5
+#define DST_OCB_STRIDE_IDX() 6
+#define FLT_OCB_STRIDE_IDX() 7
+#define FLAGS_IDX()          8
+#define KH_IDX()             9
+#define KW_IDX()             10
+
+#define CH_DT_BLK() 8
+#define CH_RF_BLK() 4
+
+#define NT_STORE_OPT() 2
+#define STRIDE_W_OPT() 3
+#define OCRF_BLK_OPT() 2
+
+#define MAX_OC_RF() 4
+#define MAX_OW_RF() 3
+
+#define BLK1X3_OC_RF() 4
+#define BLK1X3_OW_RF() 3
+
+namespace ppl { namespace kernel { namespace x86 {
+
+typedef void (*conv2d_n8cx_direct_kernel_fp32_sse_func_t)(const int64_t*, int64_t*);
+
+extern conv2d_n8cx_direct_kernel_fp32_sse_func_t
+    conv2d_n8cx_direct_kernel_fp32_sse_pad_table[NT_STORE_OPT()][OCRF_BLK_OPT()];
+extern conv2d_n8cx_direct_kernel_fp32_sse_func_t
+    conv2d_n8cx_direct_kernel_fp32_sse_o8_table[NT_STORE_OPT()][STRIDE_W_OPT()][MAX_OW_RF()];
+extern conv2d_n8cx_direct_kernel_fp32_sse_func_t
+    conv2d_n8cx_direct_kernel_fp32_sse_o16_table[NT_STORE_OPT()][STRIDE_W_OPT()][MAX_OW_RF()];
+
+}}}; // namespace ppl::kernel::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct_ndarray/avx512/conv2d_n16cx_direct_ndarray_fp32_avx512.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct_ndarray/avx512/conv2d_n16cx_direct_ndarray_fp32_avx512.cpp
@@ -274,8 +274,8 @@ ppl::common::RetCode conv2d_n16cx_direct_ndarray_fp32_avx512_manager::gen_cvt_we
 
 bool conv2d_n16cx_direct_ndarray_fp32_avx512_manager::is_supported()
 {
-    bool small_channels = param_.channels / param_.group < 16;
-    bool aligned_num_output = param_.group == 1 || param_.num_output / param_.group % 16 == 0;
+    bool small_channels = param_.channels / param_.group < OC_DT_BLK();
+    bool aligned_num_output = param_.group == 1 || param_.num_output / param_.group % OC_DT_BLK() == 0;
     return small_channels && aligned_num_output && param_.dilation_h == 1 && param_.dilation_w == 1;
 }
 

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct_ndarray/fma/conv2d_n16cx_direct_ndarray_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/direct_ndarray/fma/conv2d_n16cx_direct_ndarray_fp32_fma.cpp
@@ -281,8 +281,8 @@ ppl::common::RetCode conv2d_n16cx_direct_ndarray_fp32_fma_manager::gen_cvt_weigh
 
 bool conv2d_n16cx_direct_ndarray_fp32_fma_manager::is_supported()
 {
-    bool small_channels = param_.channels / param_.group < 16;
-    bool aligned_num_output = param_.group == 1 || param_.num_output / param_.group % 16 == 0;
+    bool small_channels = param_.channels / param_.group < OC_DT_BLK();
+    bool aligned_num_output = param_.group == 1 || param_.num_output / param_.group % OC_DT_BLK() == 0;
     return small_channels && aligned_num_output && param_.dilation_h == 1 && param_.dilation_w == 1;
 }
 

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/avx512/conv2d_n16cx_gemm_direct_fp32_avx512.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/avx512/conv2d_n16cx_gemm_direct_fp32_avx512.cpp
@@ -365,8 +365,8 @@ ppl::common::RetCode conv2d_n16cx_gemm_direct_fp32_avx512_manager::gen_cvt_weigh
 
 bool conv2d_n16cx_gemm_direct_fp32_avx512_manager::is_supported()
 {
-    bool aligned_channels   = param_.channels / param_.group % 16 == 0;
-    bool aligned_num_output = param_.num_output / param_.group % 16 == 0;
+    bool aligned_channels   = param_.channels / param_.group % CH_DT_BLK() == 0;
+    bool aligned_num_output = param_.num_output / param_.group % CH_DT_BLK() == 0;
     return ((param_.group == 1) || (aligned_channels && aligned_num_output)) && param_.is_pointwise();
 }
 

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/fma/conv2d_n16cx_gemm_direct_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/fma/conv2d_n16cx_gemm_direct_fp32_fma.cpp
@@ -371,8 +371,8 @@ ppl::common::RetCode conv2d_n16cx_gemm_direct_fp32_fma_manager::gen_cvt_weights(
 
 bool conv2d_n16cx_gemm_direct_fp32_fma_manager::is_supported()
 {
-    bool aligned_channels   = param_.channels / param_.group % 16 == 0;
-    bool aligned_num_output = param_.num_output / param_.group % 16 == 0;
+    bool aligned_channels   = param_.channels / param_.group % CH_DT_BLK() == 0;
+    bool aligned_num_output = param_.num_output / param_.group % CH_DT_BLK() == 0;
     return ((param_.group == 1) || (aligned_channels && aligned_num_output)) && param_.is_pointwise() && param_.stride_h == 1 && param_.stride_w == 1;
 }
 

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/fma/conv2d_n16cx_gemm_direct_v2_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/gemm_direct/fma/conv2d_n16cx_gemm_direct_v2_fp32_fma.cpp
@@ -347,8 +347,8 @@ ppl::common::RetCode conv2d_n16cx_gemm_direct_v2_fp32_fma_manager::gen_cvt_weigh
 
 bool conv2d_n16cx_gemm_direct_v2_fp32_fma_manager::is_supported()
 {
-    bool aligned_channels   = param_.channels / param_.group % 16 == 0;
-    bool aligned_num_output = param_.num_output / param_.group % 16 == 0;
+    bool aligned_channels   = param_.channels / param_.group % CH_DT_BLK() == 0;
+    bool aligned_num_output = param_.num_output / param_.group % CH_DT_BLK() == 0;
     return ((param_.group == 1) || (aligned_channels && aligned_num_output)) && param_.is_pointwise();
 }
 

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/implicit_gemm/fma/conv2d_n16cx_implicit_gemm_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/conv2d/implicit_gemm/fma/conv2d_n16cx_implicit_gemm_fp32_fma.cpp
@@ -677,8 +677,8 @@ bool conv2d_n16cx_implicit_gemm_fp32_fma_manager::is_supported()
     if (param_.is_pointwise() && param_.stride_h == 1 && param_.stride_w == 1) {
         return false;
     }
-    bool aligned_channels   = param_.channels / param_.group % 16 == 0;
-    bool aligned_num_output = param_.num_output / param_.group % 16 == 0;
+    bool aligned_channels   = param_.channels / param_.group % CH_DT_BLK() == 0;
+    bool aligned_num_output = param_.num_output / param_.group % CH_DT_BLK() == 0;
     return (param_.group == 1) || (aligned_channels && aligned_num_output);
 }
 

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/reorder/reorder_goidhw_gIOBidhw8i8o_fp32.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/reorder/reorder_goidhw_gIOBidhw8i8o_fp32.cpp
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <string.h>
+
+#include "ppl/kernel/x86/common/internal_include.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+#define CH_DT_BLK() 8
+
+uint64_t reorder_goidhw_gIOBidhw8i8o_fp32_get_dst_size(
+    const int32_t group,
+    const int32_t num_output,
+    const int32_t channels,
+    const int32_t kernel_d,
+    const int32_t kernel_h,
+    const int32_t kernel_w,
+    const int32_t channels_blk)
+{
+    const int32_t ic_per_gp  = channels / group;
+    const int32_t oc_per_gp  = num_output / group;
+    const int32_t padded_ic  = round_up(ic_per_gp, CH_DT_BLK());
+    const int32_t padded_oc  = round_up(oc_per_gp, CH_DT_BLK());
+    const int32_t ic_big_blk = channels_blk;
+    const int32_t ic_big_cnt = div_up(padded_ic, channels_blk);
+
+    return uint64_t(group) * ic_big_cnt * padded_oc * kernel_d * kernel_h * kernel_w * ic_big_blk * sizeof(float);
+}
+
+ppl::common::RetCode reorder_goidhw_gIOBidhw8i8o_fp32(
+    const float *src,
+    const int32_t group,
+    const int32_t num_output,
+    const int32_t channels,
+    const int32_t kernel_d,
+    const int32_t kernel_h,
+    const int32_t kernel_w,
+    const int32_t channels_blk,
+    float *dst)
+{
+    const int32_t ic_per_gp  = channels / group;
+    const int32_t oc_per_gp  = num_output / group;
+    const int32_t padded_ic  = round_up(ic_per_gp, CH_DT_BLK());
+    const int32_t padded_oc  = round_up(oc_per_gp, CH_DT_BLK());
+    const int32_t ic_big_blk = channels_blk;
+    const int32_t ic_big_cnt = div_up(padded_ic, channels_blk);
+
+    for (int64_t g = 0; g < group; ++g) {
+        for (int64_t ic_big = 0; ic_big < padded_ic; ic_big += ic_big_blk) {
+            for (int64_t ocb = 0; ocb < padded_oc; ocb += CH_DT_BLK()) {
+                const int64_t ic_big_eff = min<int64_t>(ic_per_gp - ic_big, ic_big_blk);
+                const int64_t ocb_eff    = min<int64_t>(oc_per_gp - ocb, CH_DT_BLK());
+                const float *base_src    = src + g * oc_per_gp * ic_per_gp * kernel_d * kernel_h * kernel_w + ocb * ic_per_gp * kernel_d * kernel_h * kernel_w + ic_big * kernel_d * kernel_h * kernel_w;
+                float *base_dst          = dst + g * ic_big_cnt * padded_oc * ic_big_blk * kernel_d * kernel_h * kernel_w + ic_big * padded_oc * kernel_d * kernel_h * kernel_w + ocb * ic_big_blk * kernel_d * kernel_h * kernel_w;
+                for (int64_t icb = 0; icb < ic_big_eff; icb += CH_DT_BLK()) {
+                    const int64_t icb_eff = min<int64_t>(ic_big_eff - icb, CH_DT_BLK());
+                    for (int64_t kd = 0; kd < kernel_d; ++kd) {
+                        for (int64_t kh = 0; kh < kernel_h; ++kh) {
+                            for (int64_t kw = 0; kw < kernel_w; ++kw) {
+                                const float *l_src = base_src + icb * kernel_d * kernel_h * kernel_w + kd * kernel_h * kernel_w + kh * kernel_w + kw;
+                                float *l_dst       = base_dst + icb * kernel_d * kernel_h * kernel_w * CH_DT_BLK() + kd * kernel_h * kernel_w * CH_DT_BLK() * CH_DT_BLK() + kh * kernel_w * CH_DT_BLK() * CH_DT_BLK() + kw * CH_DT_BLK() * CH_DT_BLK();
+                                int64_t ic         = 0;
+                                for (; ic < icb_eff; ++ic) {
+                                    int64_t oc = 0;
+                                    for (; oc < ocb_eff; ++oc) {
+                                        l_dst[ic * CH_DT_BLK() + oc] = l_src[(oc * ic_per_gp + ic) * kernel_d * kernel_h * kernel_w];
+                                    }
+                                    for (; oc < CH_DT_BLK(); ++oc) {
+                                        l_dst[ic * CH_DT_BLK() + oc] = 0;
+                                    }
+                                }
+                                for (; ic < CH_DT_BLK(); ++ic) {
+                                    memset(l_dst + ic * CH_DT_BLK(), 0, CH_DT_BLK() * sizeof(float));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return ppl::common::RC_SUCCESS;
+}
+
+}}}; // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/reorder/reorder_n8cx_ndarray_fp32.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/reorder/reorder_n8cx_ndarray_fp32.cpp
@@ -19,12 +19,12 @@
 
 namespace ppl { namespace kernel { namespace x86 {
 
-ppl::common::RetCode reorder_n16cx_ndarray_fp32(
+ppl::common::RetCode reorder_n8cx_ndarray_fp32(
     const ppl::nn::TensorShape *src_shape,
     const float *src,
     float *dst)
 {
-    if (src_shape->GetDataFormat() != ppl::common::DATAFORMAT_N16CX ||
+    if (src_shape->GetDataFormat() != ppl::common::DATAFORMAT_N8CX ||
         src_shape->GetDimCount() < 3) {
         return ppl::common::RC_UNSUPPORTED;
     }
@@ -33,7 +33,7 @@ ppl::common::RetCode reorder_n16cx_ndarray_fp32(
     const int64_t channels = src_shape->GetDim(1);
     const int64_t X        = src_shape->GetElementsExcludingPadding() / batch / channels;
 
-    const int64_t c_blk    = 16;
+    const int64_t c_blk    = 8;
     const int64_t padded_c = round_up(channels, c_blk);
 
 #ifdef PPL_USE_X86_OMP_COLLAPSE


### PR DESCRIPTION
 - Add conv2d_n8cx_direct_fp32_sse with unit test enabled
 - Add reorder 8c->nd, nd->8c, 8c->dhw8i8o(for cvt filter)