### PR TITLE
X86 `deform_conv2d` and `LSTM`

### DIFF
--- a/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/common/rnn_common.h
+++ b/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/common/rnn_common.h
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_FP32_RNN_COMMON_H_
+#define __ST_PPL_KERNEL_X86_FP32_RNN_COMMON_H_
+
+#include "ppl/kernel/x86/common/general_include.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+typedef uint64_t rnn_direction_t;
+
+class rnn_direction {
+public:
+    static const rnn_direction_t forward       = 0;
+    static const rnn_direction_t reverse       = 1;
+    static const rnn_direction_t bidirectional = 2;
+};
+
+class rnn_num_gate {
+public:
+    static const int64_t lstm = 4;
+    static const int64_t gru  = 3;
+};
+
+}}}; // namespace ppl::kernel::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/fp32/deform_conv2d.h
+++ b/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/fp32/deform_conv2d.h
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_FP32_DEFORM_CONV2D_H_
+#define __ST_PPL_KERNEL_X86_FP32_DEFORM_CONV2D_H_
+
+#include "ppl/kernel/x86/common/general_include.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+uint64_t deform_conv2d_ref_fp32_get_buffer_bytes(
+    const int64_t dst_h,
+    const int64_t dst_w,
+    const int64_t group,
+    const int64_t channels,
+    const int64_t kernel_h,
+    const int64_t kernel_w);
+
+ppl::common::RetCode deform_conv2d_ref_fp32(
+    const ppl::nn::TensorShape *src_shape,
+    const ppl::nn::TensorShape *dst_shape,
+    const float *src,
+    const float *offset,
+    const float *mask,
+    const float *filter,
+    const float *bias,
+    const int64_t group,
+    const int64_t offset_group,
+    const int64_t channels,
+    const int64_t num_output,
+    const int64_t kernel_h,
+    const int64_t kernel_w,
+    const int64_t stride_h,
+    const int64_t stride_w,
+    const int64_t pad_h,
+    const int64_t pad_w,
+    const int64_t dilation_h,
+    const int64_t dilation_w,
+    void *temp_buffer,
+    float *dst);
+
+}}}; // namespace ppl::kernel::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/fp32/lstm.h
+++ b/src/ppl/nn/engines/x86/impls/include/ppl/kernel/x86/fp32/lstm.h
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef __ST_PPL_KERNEL_X86_FP32_LSTM_H_
+#define __ST_PPL_KERNEL_X86_FP32_LSTM_H_
+
+#include "ppl/kernel/x86/common/general_include.h"
+#include "ppl/kernel/x86/common/rnn_common.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+uint64_t lstm_ref_fp32_get_buffer_bytes(
+    const ppl::nn::TensorShape *X_shape,
+    const rnn_direction_t direction,
+    const int64_t hidden_size,
+    const bool has_Y,
+    const bool has_Y_h,
+    const bool has_Y_c);
+
+ppl::common::RetCode lstm_ref_fp32(
+    const ppl::nn::TensorShape *X_shape,
+    const float *X,
+    const float *X_weight,
+    const float *R_weight,
+    const float *P_weight,
+    const float *bias,
+    const int32_t *sequence_lens,
+    const float *initial_h,
+    const float *initial_c,
+    const rnn_direction_t direction,
+    const int64_t hidden_size,
+    void *temp_buffer,
+    float *Y,
+    float *Y_h,
+    float *Y_c);
+
+}}}; // namespace ppl::kernel::x86
+
+#endif //! __ST_PPL_KERNEL_X86_FP32_GEMM_H_

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/deform_conv2d/deform_conv2d_ref_fp32.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/deform_conv2d/deform_conv2d_ref_fp32.cpp
@@ -1,0 +1,233 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <math.h>
+
+#include "ppl/kernel/x86/common/internal_include.h"
+#include "ppl/kernel/x86/fp32/gemm.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+template <typename eT>
+static eT bilinear_interpolate_2d(
+    const eT* src,
+    const int64_t src_h,
+    const int64_t src_w,
+    const eT h,
+    const eT w)
+{
+    if (h <= -1 || src_h <= h || w <= -1 || src_w <= w) {
+        return 0;
+    }
+
+    int64_t h_low = ::floor(h);
+    int64_t w_low = ::floor(w);
+    int64_t h_high = h_low + 1;
+    int64_t w_high = w_low + 1;
+
+    eT lh = h - h_low;
+    eT lw = w - w_low;
+    eT hh = 1 - lh;
+    eT hw = 1 - lw;
+
+    eT v1 = 0;
+    if (h_low >= 0 && w_low >= 0)
+        v1 = src[h_low * src_w + w_low];
+    eT v2 = 0;
+    if (h_low >= 0 && w_high <= src_w - 1)
+        v2 = src[h_low * src_w + w_high];
+    eT v3 = 0;
+    if (h_high <= src_h - 1 && w_low >= 0)
+        v3 = src[h_high * src_w + w_low];
+    eT v4 = 0;
+    if (h_high <= src_h - 1 && w_high <= src_w - 1)
+        v4 = src[h_high * src_w + w_high];
+
+    eT w1 = hh * hw, w2 = hh * lw, w3 = lh * hw, w4 = lh * lw;
+
+    eT val = (w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4);
+    return val;
+}
+
+// output: (channels * kernel_h * kernel_w, dst_h * dst_w)
+template <typename eT>
+static void deform_im2col_2d(
+    const eT* input,
+    const eT* offset,
+    const eT* mask,
+    const int64_t src_h,
+    const int64_t src_w,
+    const int64_t kernel_h,
+    const int64_t kernel_w,
+    const int64_t pad_h,
+    const int64_t pad_w,
+    const int64_t stride_h,
+    const int64_t stride_w,
+    const int64_t dilation_h,
+    const int64_t dilation_w,
+    const int64_t channels,
+    const int64_t offset_groups,
+    const int64_t dst_h,
+    const int64_t dst_w,
+    const bool use_mask,
+    eT* columns)
+{
+    const int64_t workload = channels * dst_h * dst_w;
+PRAGMA_OMP_PARALLEL_FOR()
+    for (int64_t index = 0; index < workload; ++index) {
+        const int64_t ow = index % dst_w;
+        const int64_t oh = (index / dst_w) % dst_h;
+        const int64_t ic = index / (dst_w * dst_h);
+        const int64_t oc = ic * kernel_h * kernel_w;
+
+        int64_t c_per_offset_grp = channels / offset_groups;
+        const int64_t grp_idx = ic / c_per_offset_grp;
+
+        auto columns_ptr = columns + (oc * (dst_h * dst_w) + oh * dst_w + ow);
+        auto input_ptr = input + ic * (src_h * src_w);
+        auto offset_ptr = offset + grp_idx * 2 * kernel_h * kernel_w * dst_h * dst_w;
+        auto mask_ptr = mask;
+        if (use_mask) {
+            mask_ptr += grp_idx * kernel_h * kernel_w * dst_h * dst_w;
+        }
+
+        for (int64_t kh = 0; kh < kernel_h; ++kh) {
+            for (int64_t kw = 0; kw < kernel_w; ++kw) {
+                const int64_t mask_idx = kh * kernel_w + kw;
+                const int64_t offset_idx = 2 * mask_idx;
+
+                eT mask_value = 1;
+                if (use_mask) {
+                mask_value =
+                    mask_ptr[mask_idx * (dst_h * dst_w) + oh * dst_w + ow];
+                }
+
+                const eT offset_h = offset_ptr[offset_idx * (dst_h * dst_w) + oh * dst_w + ow];
+                const eT offset_w = offset_ptr[(offset_idx + 1) * (dst_h * dst_w) + oh * dst_w + ow];
+                const eT ih = (oh * stride_h - pad_h) + kh * dilation_h + offset_h;
+                const eT iw = (ow * stride_w - pad_w) + kw * dilation_w + offset_w;
+                *columns_ptr = mask_value * bilinear_interpolate_2d(input_ptr, src_h, src_w, ih, iw);
+                columns_ptr += dst_h * dst_w;
+            }
+        }
+    }
+}
+
+uint64_t deform_conv2d_ref_fp32_get_buffer_bytes(
+    const int64_t dst_h,
+    const int64_t dst_w,
+    const int64_t group,
+    const int64_t channels,
+    const int64_t kernel_h,
+    const int64_t kernel_w)
+{
+    const int64_t ic_per_gp = channels / group;
+    if (ic_per_gp * group != channels) {
+        return 64u;
+    }
+    return ic_per_gp * kernel_h * kernel_w * dst_h * dst_w * sizeof(float);
+}
+
+ppl::common::RetCode deform_conv2d_ref_fp32(
+    const ppl::nn::TensorShape *src_shape,
+    const ppl::nn::TensorShape *dst_shape,
+    const float *src,
+    const float *offset,
+    const float *mask,
+    const float *filter,
+    const float *bias,
+    const int64_t group,
+    const int64_t offset_group,
+    const int64_t channels,
+    const int64_t num_output,
+    const int64_t kernel_h,
+    const int64_t kernel_w,
+    const int64_t stride_h,
+    const int64_t stride_w,
+    const int64_t pad_h,
+    const int64_t pad_w,
+    const int64_t dilation_h,
+    const int64_t dilation_w,
+    void *temp_buffer,
+    float *dst)
+{
+    if (channels % group != 0 || num_output % group != 0) {
+        return ppl::common::RC_INVALID_VALUE;
+    }
+
+    const int64_t batch = src_shape->GetDim(0);
+    const int64_t src_c = src_shape->GetDim(1);
+    const int64_t src_h = src_shape->GetDim(2);
+    const int64_t src_w = src_shape->GetDim(3);
+    const int64_t dst_c = dst_shape->GetDim(1);
+    const int64_t dst_h = dst_shape->GetDim(2);
+    const int64_t dst_w = dst_shape->GetDim(3);
+
+    const int64_t ic_per_gp = channels / group;
+    const int64_t oc_per_gp = num_output / group;
+    float *columns = reinterpret_cast<float*>(temp_buffer);
+    for (int64_t b = 0; b < batch; ++b) {
+        for (int64_t g = 0; g < group; ++g) {
+            deform_im2col_2d(
+                src + b * src_c * src_h * src_w + g * ic_per_gp * src_h * src_w,
+                offset + b * offset_group * 2 * kernel_h * kernel_w * dst_h * dst_w,
+                mask + b * offset_group * kernel_h * kernel_w * dst_h * dst_w,
+                src_h, src_w,
+                kernel_h, kernel_w,
+                pad_h, pad_w,
+                stride_h, stride_w,
+                dilation_h, dilation_w,
+                ic_per_gp,
+                offset_group,
+                dst_h, dst_w,
+                mask != nullptr,
+                columns);
+            float *dst_ptr = dst + b * dst_c * dst_h * dst_w + g * oc_per_gp * dst_h * dst_w;
+            if (bias != nullptr) {
+                const float *bias_ptr = bias + g * oc_per_gp;
+PRAGMA_OMP_PARALLEL_FOR()
+                for (int64_t oc = 0; oc < oc_per_gp; ++oc) {
+                    for (int64_t hw = 0; hw < dst_h * dst_w; ++hw) {
+                        dst_ptr[oc * dst_h * dst_w + hw] = bias_ptr[oc];
+                    }
+                }
+            } else {
+PRAGMA_OMP_PARALLEL_FOR()
+                for (int64_t oc = 0; oc < oc_per_gp; ++oc) {
+                    for (int64_t hw = 0; hw < dst_h * dst_w; ++hw) {
+                        dst_ptr[oc * dst_h * dst_w + hw] = 0.0f;
+                    }
+                }
+            }
+            gemm_ref_fp32(
+                filter + g * oc_per_gp * ic_per_gp * kernel_h * kernel_w,
+                columns,
+                nullptr,
+                dst_ptr,
+                0, 0,
+                oc_per_gp,
+                dst_h * dst_w,
+                ic_per_gp * kernel_h * kernel_w,
+                1.0f, 1.0f,
+                dst_ptr);
+        }
+    }
+
+    return ppl::common::RC_SUCCESS;
+}
+
+}}}; // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/gemm/gemm_ref_fp32.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/gemm/gemm_ref_fp32.cpp
@@ -42,29 +42,33 @@ ppl::common::RetCode gemm_ref_fp32(
 #endif
         for (int64_t n = 0; n < N; ++n) {
             float y = 0.0f;
-            if (!trans_A && !trans_B) { // MK, KN; NN
-                for (int64_t k = 0; k < K; ++k) {
-                    y += A[m * K + k] * B[k * N + n];
+            if (alpha != 0.0f) {
+                if (!trans_A && !trans_B) { // MK, KN; NN
+                    for (int64_t k = 0; k < K; ++k) {
+                        y += A[m * K + k] * B[k * N + n];
+                    }
                 }
-            }
-            if (trans_A && !trans_B) { // KM, KN; TN
-                for (int64_t k = 0; k < K; ++k) {
-                    y += A[k * M + m] * B[k * N + n];
+                if (trans_A && !trans_B) { // KM, KN; TN
+                    for (int64_t k = 0; k < K; ++k) {
+                        y += A[k * M + m] * B[k * N + n];
+                    }
                 }
-            }
-            if (trans_A && trans_B) { // KM, NK; TT
-                for (int64_t k = 0; k < K; ++k) {
-                    y += A[k * M + m] * B[n * K + k];
+                if (trans_A && trans_B) { // KM, NK; TT
+                    for (int64_t k = 0; k < K; ++k) {
+                        y += A[k * M + m] * B[n * K + k];
+                    }
                 }
-            }
-            if (!trans_A && trans_B) { // MK, NK; NT
-                for (int64_t k = 0; k < K; ++k) {
-                    y += A[m * K + k] * B[n * K + k];
+                if (!trans_A && trans_B) { // MK, NK; NT
+                    for (int64_t k = 0; k < K; ++k) {
+                        y += A[m * K + k] * B[n * K + k];
+                    }
                 }
+                y *= alpha;
             }
-            y *= alpha;
-            if (V) y += beta * V[n];
-            if (H) y += beta * H[m * N + n];
+            if (beta != 0.0f) {
+                if (V) y += beta * V[n];
+                if (H) y += beta * H[m * N + n];
+            }
             Y[m * N + n] = y;
         }
     }

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/lstm/lstm_ref_fp32.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/lstm/lstm_ref_fp32.cpp
@@ -1,0 +1,216 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <math.h>
+#include <string.h>
+
+#include "ppl/kernel/x86/common/internal_include.h"
+#include "ppl/kernel/x86/fp32/lstm.h"
+#include "ppl/kernel/x86/fp32/gemm.h"
+
+namespace ppl { namespace kernel { namespace x86 {
+
+static inline float sigmoidf(const float x) {
+    return 1.0f / (1.0f + expf(-x));
+}
+
+uint64_t lstm_ref_fp32_get_buffer_bytes(
+    const ppl::nn::TensorShape *X_shape,
+    const rnn_direction_t direction,
+    const int64_t hidden_size,
+    const bool has_Y,
+    const bool has_Y_h,
+    const bool has_Y_c)
+{
+    if (!has_Y && !has_Y_h && !has_Y_c)
+        return 64u;
+
+    const int64_t batch = X_shape->GetDim(1);
+    const int64_t num_direction = direction == rnn_direction::bidirectional ? 2 : 1;
+
+    const uint64_t gate_buff_size = batch * rnn_num_gate::lstm * hidden_size;
+    const uint64_t yh_size = has_Y_h ? num_direction * batch * hidden_size : 0;
+    const uint64_t yc_size = has_Y_c ? num_direction * batch * hidden_size : 0;
+
+    return (gate_buff_size + yh_size + yc_size) * sizeof(float);
+}
+
+ppl::common::RetCode lstm_ref_fp32(
+    const ppl::nn::TensorShape *X_shape,
+    const float *X,
+    const float *X_weight,
+    const float *R_weight,
+    const float *P_weight,
+    const float *bias,
+    const int32_t *sequence_lens,
+    const float *initial_h,
+    const float *initial_c,
+    const rnn_direction_t direction,
+    const int64_t hidden_size,
+    void *temp_buffer,
+    float *Y,
+    float *Y_h,
+    float *Y_c)
+{
+    if (!Y && !Y_h && !Y_c) {
+        return ppl::common::RC_SUCCESS;
+    }
+
+    const int64_t num_direction = direction == rnn_direction::bidirectional ? 2 : 1;
+    const int64_t seq_len = X_shape->GetDim(0);
+    const int64_t batch = X_shape->GetDim(1);
+    const int64_t input_size = X_shape->GetDim(2);
+
+    float *Yh_buf = Y_h;
+    float *Yc_buf = Y_c;
+
+    // set temp buffer
+    float *temp_buffer_fp32 = reinterpret_cast<float*>(temp_buffer);
+    if (!Yh_buf) {
+        Yh_buf = temp_buffer_fp32;
+        temp_buffer_fp32 += num_direction * batch * hidden_size;
+    }
+    if (!Yc_buf) {
+        Yc_buf = temp_buffer_fp32;
+        temp_buffer_fp32 += num_direction * batch * hidden_size;
+    }
+    float *gate_buf = temp_buffer_fp32;
+
+    for (int64_t nd = 0; nd < num_direction; ++nd) {
+        const bool is_reverse = nd || (direction == rnn_direction::reverse);
+
+        float *nd_Yh = Yh_buf + nd * batch * hidden_size;
+        float *nd_Yc = Yc_buf + nd * batch * hidden_size;
+        float *nd_Y = Y + nd * batch * hidden_size;
+
+        const float *nd_W = X_weight + nd * rnn_num_gate::lstm * hidden_size * input_size;
+        const float *nd_R = R_weight + nd * rnn_num_gate::lstm * hidden_size * hidden_size;
+        const float *nd_P = P_weight ? P_weight + nd * (rnn_num_gate::lstm - 1) * hidden_size : nullptr;
+        const float *nd_Wb = bias ? bias + nd * 2 * rnn_num_gate::lstm * hidden_size : nullptr;
+        const float *nd_Rb = bias ? nd_Wb + rnn_num_gate::lstm * hidden_size : nullptr;
+
+        const float *nd_init_h = initial_h ? initial_h + nd * batch * hidden_size : nullptr;
+        const float *nd_init_c = initial_c ? initial_c + nd * batch * hidden_size : nullptr;
+
+        for (int64_t seq_idx = 0; seq_idx < seq_len; ++seq_idx) {
+            const int64_t mapped_seq_index = is_reverse ? (seq_len - seq_idx - 1) : seq_idx;
+            const bool is_first_seq = seq_idx == 0;
+
+            // X (seq_len, batch, input_size)
+            // h_0 (num_direction, batch, hidden_size)
+            // c_0 (num_direction, batch, hidden_size)
+            // Y (seq_len, num_direction, batch, hidden_size)
+            // h_n (num_direction, batch, hidden_size)
+            // c_n (num_direction, batch, hidden_size)
+
+            const float *sX = X + mapped_seq_index * batch * input_size;
+            const float *Y_h_prev = is_first_seq ? nd_init_h : nd_Yh;
+            const float *Y_c_prev = is_first_seq ? nd_init_c : nd_Yc;
+            float *sY = nd_Y + mapped_seq_index * num_direction * batch * hidden_size;
+
+            gemm_ref_fp32( // X[s]*W[nd]_{iofc}^T+Wb_{iofc}
+                sX, nd_W, nd_Wb, nullptr, 0, 1, batch, rnn_num_gate::lstm * hidden_size, input_size, 1.0f, 1.0f, gate_buf);
+
+            const float alpha = !Y_h_prev ? 0.0f : 1.0f; // some hack, gemm will skip aAxB if alpha is 0
+            gemm_ref_fp32( // h_0[nd]*R[nd]_{iofc}^T+Rb_{iofc}
+                Y_h_prev, nd_R, nd_Rb, gate_buf, 0, 1, batch, rnn_num_gate::lstm * hidden_size, hidden_size, alpha, 1.0f, gate_buf);
+
+            if (is_first_seq && !Y_h_prev) {
+                Y_h_prev = nd_Yh; // preprocess Y_h_prev
+                memset(nd_Yh, 0, batch * hidden_size * sizeof(float));
+            }
+            if (is_first_seq && !Y_c_prev) {
+                Y_c_prev = nd_Yc; // preprocess Y_c_prev
+                memset(nd_Yc, 0, batch * hidden_size * sizeof(float));
+            }
+
+            if (!P_weight) {
+PRAGMA_OMP_PARALLEL_FOR()
+                for (int64_t b = 0; b < batch; ++b) {
+                    if (!sequence_lens || seq_idx < sequence_lens[b]) {
+                        const float *gI = gate_buf + b * rnn_num_gate::lstm * hidden_size;
+                        const float *gO = gI + hidden_size;
+                        const float *gF = gO + hidden_size;
+                        const float *gC = gF + hidden_size;
+                        const float *Cprev = Y_c_prev + b * hidden_size;
+                        float *Ct = nd_Yc + b * hidden_size;
+                        float *Ht = nd_Yh + b * hidden_size;
+                        float *Yt = sY + b * hidden_size;
+                        for (int64_t h = 0; h < hidden_size; ++h) {
+                            const float it = sigmoidf(gI[h]);
+                            const float ft = sigmoidf(gF[h]);
+                            const float ct = ::tanhf(gC[h]);
+                            Ct[h] = ft * Cprev[h] + it * ct;
+                            const float ot = sigmoidf(gO[h]);
+                            Ht[h] = ot * ::tanhf(Ct[h]);
+                        }
+                        if (Y) {
+                            memcpy(Yt, Ht, hidden_size * sizeof(float));
+                        }
+                    } else { // pass through the initial_h, initial_c
+                        const float *Hprev = Y_h_prev + b * hidden_size;
+                        const float *Cprev = Y_c_prev + b * hidden_size;
+                        float *Ct = nd_Yc + b * hidden_size;
+                        float *Ht = nd_Yh + b * hidden_size;
+                        memcpy(Ct, Cprev, hidden_size * sizeof(float));
+                        memcpy(Ht, Hprev, hidden_size * sizeof(float));
+                    }
+                }
+            } else {
+                const float *pI = nd_P;
+                const float *pO = pI + hidden_size;
+                const float *pF = pO + hidden_size;
+PRAGMA_OMP_PARALLEL_FOR()
+                for (int64_t b = 0; b < batch; ++b) {
+                    if (!sequence_lens || seq_idx < sequence_lens[b]) {
+                        const float *gI = gate_buf + b * rnn_num_gate::lstm * hidden_size;
+                        const float *gO = gI + hidden_size;
+                        const float *gF = gO + hidden_size;
+                        const float *gC = gF + hidden_size;
+                        const float *Cprev = Y_c_prev + b * hidden_size;
+                        float *Ct = nd_Yc + b * hidden_size;
+                        float *Ht = nd_Yh + b * hidden_size;
+                        float *Yt = sY + b * hidden_size;
+                        for (int64_t h = 0; h < hidden_size; ++h) {
+                            const float it = sigmoidf(gI[h] + pI[h] * Cprev[h]);
+                            const float ft = sigmoidf(gF[h] + pF[h] * Cprev[h]);
+                            const float ct = ::tanhf(gC[h]);
+                            Ct[h] = ft * Cprev[h] + it * ct;
+                            const float ot = sigmoidf(gO[h] + pO[h] * Ct[h]);
+                            Ht[h] = ot * ::tanhf(Ct[h]);
+                        }
+                        if (Y) {
+                            memcpy(Yt, Ht, hidden_size * sizeof(float));
+                        }
+                    } else { // pass through the initial_h, initial_c
+                        const float *Hprev = Y_h_prev + b * hidden_size;
+                        const float *Cprev = Y_c_prev + b * hidden_size;
+                        float *Ct = nd_Yc + b * hidden_size;
+                        float *Ht = nd_Yh + b * hidden_size;
+                        memcpy(Ct, Cprev, hidden_size * sizeof(float));
+                        memcpy(Ht, Hprev, hidden_size * sizeof(float));
+                    }
+                }
+            }
+        }
+    }
+
+    return ppl::common::RC_SUCCESS;
+}
+
+
+}}}; // namespace ppl::kernel::x86

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/softmax/softmax_fp32.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/softmax/softmax_fp32.cpp
@@ -42,9 +42,17 @@ ppl::common::RetCode softmax_ndarray_fp32(
         const float *p_src = src + i * axis_dim * inner_dim;
         float *p_dst       = dst + i * axis_dim * inner_dim;
 
+        // find max
+        float max_val = p_src[0];
+        for (int64_t j = 1; j < axis_dim * inner_dim; j++) {
+            if (p_src[j] > max_val) {
+                max_val = p_src[j];
+            }
+        }
+
         float exp_sum = 0.0f;
         for (int64_t j = 0; j < axis_dim * inner_dim; j++) {
-            float exp_val = expf(p_src[j]);
+            float exp_val = expf(p_src[j] - max_val);
             p_dst[j]      = exp_val;
             exp_sum += exp_val;
         }

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/softmax/softmax_fp32.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/softmax/softmax_fp32.cpp
@@ -37,7 +37,7 @@ ppl::common::RetCode softmax_ndarray_fp32(
         inner_dim *= src_shape->GetDim(i);
     }
 
-    PRAGMA_OMP_PARALLEL_FOR()
+PRAGMA_OMP_PARALLEL_FOR()
     for (int64_t i = 0; i < outer_dim; i++) {
         const float *p_src = src + i * axis_dim * inner_dim;
         float *p_dst       = dst + i * axis_dim * inner_dim;

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/softmax/softmax_fp32_fma.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/softmax/softmax_fp32_fma.cpp
@@ -42,7 +42,7 @@ ppl::common::RetCode softmax_ndarray_fp32_fma(
 
     const int64_t simd_w = 8;
 
-    PRAGMA_OMP_PARALLEL_FOR()
+PRAGMA_OMP_PARALLEL_FOR()
     for (int64_t i = 0; i < outer_dim; i++) {
         const float *p_src = src + i * axis_dim * inner_dim;
         float *p_dst       = dst + i * axis_dim * inner_dim;
@@ -72,7 +72,7 @@ ppl::common::RetCode softmax_ndarray_fp32_fma(
             v_exp_sum = _mm256_add_ps(v_exp_sum, v_exp_val);
         }
         for (; j < axis_dim * inner_dim; j++) {
-            float exp_val = expf(p_src[j]);
+            float exp_val = expf(p_src[j] - max_val);
             p_dst[j]      = exp_val;
             exp_sum += exp_val;
         }

--- a/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/softmax/softmax_fp32_sse.cpp
+++ b/src/ppl/nn/engines/x86/impls/src/ppl/kernel/x86/fp32/softmax/softmax_fp32_sse.cpp
@@ -42,7 +42,7 @@ ppl::common::RetCode softmax_ndarray_fp32_sse(
 
     const int64_t simd_w = 4;
 
-    PRAGMA_OMP_PARALLEL_FOR()
+PRAGMA_OMP_PARALLEL_FOR()
     for (int64_t i = 0; i < outer_dim; i++) {
         const float *p_src = src + i * axis_dim * inner_dim;
         float *p_dst       = dst + i * axis_dim * inner_dim;
@@ -73,7 +73,7 @@ ppl::common::RetCode softmax_ndarray_fp32_sse(
             v_exp_sum = _mm_add_ps(v_exp_sum, v_exp_val);
         }
         for (; j < axis_dim * inner_dim; j++) {
-            float exp_val = expf(p_src[j]);
+            float exp_val = expf(p_src[j] - max_val);
             p_dst[j]      = exp_val;
             exp_sum += exp_val;
         }

--- a/src/ppl/nn/engines/x86/kernels/mmcv/mmcv_gridsample_kernel.cc
+++ b/src/ppl/nn/engines/x86/kernels/mmcv/mmcv_gridsample_kernel.cc
@@ -37,7 +37,7 @@ ppl::common::RetCode MMCVGridSampleKernel::DoExecute(KernelExecContext* ctx) {
     PPLNN_X86_DEBUG_TRACE("interpolation_mode: %ld\n", param_->interpolation_mode);
     PPLNN_X86_DEBUG_TRACE("padding_mode: %ld\n", param_->padding_mode);
 
-    if (param_->padding_mode == 0) { // bilinear
+    if (param_->interpolation_mode == 0) { // bilinear
         if (false) {
         }
 #ifdef PPL_USE_X86_AVX512

--- a/src/ppl/nn/engines/x86/kernels/mmcv/mmcv_modulated_deform_conv2d_kernel.cc
+++ b/src/ppl/nn/engines/x86/kernels/mmcv/mmcv_modulated_deform_conv2d_kernel.cc
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/nn/engines/x86/kernels/mmcv/mmcv_modulated_deform_conv2d_kernel.h"
+
+#include "ppl/kernel/x86/fp32/deform_conv2d.h"
+
+namespace ppl { namespace nn { namespace x86 {
+
+uint64_t MMCVModulatedDeformConv2dKernel::CalcTmpBufferSize(const KernelExecContext& ctx) const {
+    auto weight = ctx.GetInput<TensorImpl>(3);
+    auto output = ctx.GetOutput<TensorImpl>(0);
+    auto channels = weight->GetShape().GetDim(1) * param_->groups;
+    return ppl::kernel::x86::deform_conv2d_ref_fp32_get_buffer_bytes(
+        output->GetShape().GetDim(2), output->GetShape().GetDim(3), param_->groups,
+        channels, weight->GetShape().GetDim(2), weight->GetShape().GetDim(3));
+}
+
+ppl::common::RetCode MMCVModulatedDeformConv2dKernel::DoExecute(KernelExecContext* ctx) {
+    PPLNN_X86_REQUIRED_INPUT(input, 0);
+    PPLNN_X86_REQUIRED_INPUT(offset, 1);
+    PPLNN_X86_REQUIRED_INPUT(mask, 2);
+    PPLNN_X86_REQUIRED_INPUT(weight, 3);
+    PPLNN_X86_OPTIONAL_INPUT(bias, 4);
+    PPLNN_X86_REQUIRED_OUTPUT(output, 0);
+
+    PPLNN_X86_DEBUG_TRACE("Op: %s\n", GetName().c_str());
+    PPLNN_X86_DEBUG_TRACE("Input [input]:\n");
+    PPL_X86_TENSOR_PRINT_DEBUG_MSG(input);
+    PPLNN_X86_DEBUG_TRACE("Input [offset]:\n");
+    PPL_X86_TENSOR_PRINT_DEBUG_MSG(offset);
+    PPLNN_X86_DEBUG_TRACE("Input [mask]:\n");
+    PPL_X86_TENSOR_PRINT_DEBUG_MSG(mask);
+    PPLNN_X86_DEBUG_TRACE("Input [weight]:\n");
+    PPL_X86_TENSOR_PRINT_DEBUG_MSG(weight);
+    PPLNN_X86_DEBUG_TRACE("Output [output]:\n");
+    PPL_X86_TENSOR_PRINT_DEBUG_MSG(output);
+    PPLNN_X86_DEBUG_TRACE("stride: %ld, %ld\n", param_->stride[0], param_->stride[1]);
+    PPLNN_X86_DEBUG_TRACE("padding: %ld, %ld\n", param_->padding[0], param_->padding[1]);
+    PPLNN_X86_DEBUG_TRACE("dilation: %ld, %ld\n", param_->dilation[0], param_->dilation[1]);
+    PPLNN_X86_DEBUG_TRACE("groups: %ld\n", param_->groups);
+    PPLNN_X86_DEBUG_TRACE("deform_groups: %ld\n", param_->deform_groups);
+
+    BufferDesc tmp_buffer_desc;
+    auto tmp_buffer_size = CalcTmpBufferSize(*ctx);
+    auto status = GetX86Device()->AllocTmpBuffer(tmp_buffer_size, &tmp_buffer_desc);
+    if (status != ppl::common::RC_SUCCESS) {
+        LOG(ERROR) << "alloc tmp buffer size[" << tmp_buffer_size << "] for kernel[" << GetName()
+                   << "] failed: " << ppl::common::GetRetCodeStr(status);
+        return status;
+    }
+    BufferDescGuard __tmp_buffer_guard(&tmp_buffer_desc, [this](BufferDesc* buffer) -> void {
+        GetX86Device()->FreeTmpBuffer(buffer);
+    });
+    auto tmp_buffer = tmp_buffer_desc.addr;
+
+    const int64_t num_output = weight->GetShape().GetDim(0);
+    const int64_t channels = weight->GetShape().GetDim(1) * param_->groups;
+    const int64_t kernel_h = weight->GetShape().GetDim(2);
+    const int64_t kernel_w = weight->GetShape().GetDim(3);
+
+    const float *b_data = nullptr;
+    if (bias) {
+        b_data = bias->GetBufferPtr<const float>();
+    }
+
+    return ppl::kernel::x86::deform_conv2d_ref_fp32(
+        &input->GetShape(), &output->GetShape(),
+        input->GetBufferPtr<const float>(), offset->GetBufferPtr<const float>(),
+        mask->GetBufferPtr<const float>(), weight->GetBufferPtr<const float>(), b_data,
+        param_->groups, param_->deform_groups, channels, num_output,
+        kernel_h, kernel_w, param_->stride[0], param_->stride[1],
+        param_->padding[0], param_->padding[1], param_->dilation[0], param_->dilation[1],
+        tmp_buffer, output->GetBufferPtr<float>());
+}
+
+}}} // namespace ppl::nn::x86

--- a/src/ppl/nn/engines/x86/kernels/mmcv/mmcv_modulated_deform_conv2d_kernel.h
+++ b/src/ppl/nn/engines/x86/kernels/mmcv/mmcv_modulated_deform_conv2d_kernel.h
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef _ST_HPC_PPL_NN_ENGINES_X86_KERNELS_MMCV_MODULATED_DEFORM_CONV2D_KERNEL_H_
+#define _ST_HPC_PPL_NN_ENGINES_X86_KERNELS_MMCV_MODULATED_DEFORM_CONV2D_KERNEL_H_
+
+#include "ppl/nn/engines/x86/kernel.h"
+#include "ppl/nn/params/mmcv/mmcv_modulated_deform_conv2d_param.h"
+
+namespace ppl { namespace nn { namespace x86 {
+
+class MMCVModulatedDeformConv2dKernel : public X86Kernel {
+public:
+    MMCVModulatedDeformConv2dKernel(const ir::Node* node) : X86Kernel(node) {}
+
+    void SetParam(const ppl::nn::common::MMCVModulatedDeformConv2dParam* p) {
+        param_ = p;
+    }
+
+private:
+    uint64_t CalcTmpBufferSize(const KernelExecContext& ctx) const override;
+    ppl::common::RetCode DoExecute(KernelExecContext*) override;
+
+private:
+    const ppl::nn::common::MMCVModulatedDeformConv2dParam* param_ = nullptr;
+};
+
+}}} // namespace ppl::nn::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/kernels/onnx/conv/conv2d_dynamic_kernel.cc
+++ b/src/ppl/nn/engines/x86/kernels/onnx/conv/conv2d_dynamic_kernel.cc
@@ -22,11 +22,12 @@ namespace ppl { namespace nn { namespace x86 {
 
 uint64_t Conv2dDynamicKernel::CalcTmpBufferSize(const KernelExecContext& ctx) const {
     auto x = ctx.GetInput<TensorImpl>(0);
+    auto w = ctx.GetInput<TensorImpl>(1);
     auto y = ctx.GetOutput<TensorImpl>(0);
 
     const int32_t batch = x->GetShape().GetDim(0);
-    const int32_t num_output = y->GetShape().GetDim(1);
-    const int32_t channels = x->GetShape().GetDim(1);
+    const int32_t num_output = w->GetShape().GetDim(0);
+    const int32_t channels = w->GetShape().GetDim(1) * param_->group;
     const int32_t dst_h = y->GetShape().GetDim(2);
     const int32_t dst_w = y->GetShape().GetDim(3);
 
@@ -94,6 +95,7 @@ ppl::common::RetCode Conv2dDynamicKernel::DoExecute(KernelExecContext* ctx) {
     }
 
     const int32_t num_output = W->GetShape().GetDim(0);
+    const int32_t channels = W->GetShape().GetDim(1) * param_->group;
     if (B) {
         b_data = B->GetBufferPtr<float>();
     }
@@ -119,7 +121,6 @@ ppl::common::RetCode Conv2dDynamicKernel::DoExecute(KernelExecContext* ctx) {
     PPLNN_X86_DEBUG_TRACE("isa: %u\n", GetISA());
 
     const int32_t batch = X->GetShape().GetDim(0);
-    const int32_t channels = X->GetShape().GetDim(1);
     const int32_t src_h = X->GetShape().GetDim(2);
     const int32_t src_w = X->GetShape().GetDim(3);
     const int32_t dst_h = Y->GetShape().GetDim(2);

--- a/src/ppl/nn/engines/x86/kernels/onnx/lstm_kernel.cc
+++ b/src/ppl/nn/engines/x86/kernels/onnx/lstm_kernel.cc
@@ -1,0 +1,164 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/nn/engines/x86/kernels/onnx/lstm_kernel.h"
+#include "ppl/kernel/x86/fp32/lstm.h"
+
+namespace ppl { namespace nn { namespace x86 {
+
+bool LSTMKernel::CanDoExecute(const KernelExecContext& ctx) const {
+    if (ctx.GetInputCount() < 3) {
+        return false;
+    }
+
+    auto X = ctx.GetInput<TensorImpl>(0);
+    auto W = ctx.GetInput<TensorImpl>(1);
+    auto R = ctx.GetInput<TensorImpl>(2);
+
+    if (!X || !W || !R) {
+        return false;
+    }
+
+    return true;
+}
+
+uint64_t LSTMKernel::CalcTmpBufferSize(const KernelExecContext& ctx) const {
+    auto X = ctx.GetInput<TensorImpl>(0);
+    const bool has_Y = ctx.GetOutputCount() > 0 && ctx.GetOutput<TensorImpl>(0);
+    const bool has_Y_h = ctx.GetOutputCount() > 1 && ctx.GetOutput<TensorImpl>(1);
+    const bool has_Y_c = ctx.GetOutputCount() > 2 && ctx.GetOutput<TensorImpl>(2);
+    return kernel::x86::lstm_ref_fp32_get_buffer_bytes(
+        &X->GetShape(), direction_, param_->hidden_size, has_Y, has_Y_h, has_Y_c);
+}
+
+ppl::common::RetCode LSTMKernel::DoExecute(KernelExecContext* ctx) {
+    PPLNN_X86_REQUIRED_INPUT(X, 0);
+    PPLNN_X86_REQUIRED_INPUT(W, 1);
+    PPLNN_X86_REQUIRED_INPUT(R, 2);
+    PPLNN_X86_OPTIONAL_INPUT(B, 3);
+    PPLNN_X86_OPTIONAL_INPUT(sequence_lens, 4);
+    PPLNN_X86_OPTIONAL_INPUT(initial_h, 5);
+    PPLNN_X86_OPTIONAL_INPUT(initial_c, 6);
+    PPLNN_X86_OPTIONAL_INPUT(P, 7);
+    PPLNN_X86_OPTIONAL_OUTPUT(Y, 0);
+    PPLNN_X86_OPTIONAL_OUTPUT(Y_h, 1);
+    PPLNN_X86_OPTIONAL_OUTPUT(Y_c, 2);
+
+    BufferDesc tmp_buffer_desc;
+    auto tmp_buffer_size = CalcTmpBufferSize(*ctx);
+    auto status = GetX86Device()->AllocTmpBuffer(tmp_buffer_size, &tmp_buffer_desc);
+    if (status != ppl::common::RC_SUCCESS) {
+        LOG(ERROR) << "alloc tmp buffer size[" << tmp_buffer_size << "] for kernel[" << GetName()
+                   << "] failed: " << ppl::common::GetRetCodeStr(status);
+        return status;
+    }
+    BufferDescGuard __tmp_buffer_guard(&tmp_buffer_desc, [this](BufferDesc* buffer) -> void {
+        GetX86Device()->FreeTmpBuffer(buffer);
+    });
+    auto tmp_buffer = tmp_buffer_desc.addr;
+
+    const float *B_data = nullptr;
+    const int32_t *sequence_lens_data = nullptr;
+    const float *initial_h_data = nullptr;
+    const float *initial_c_data = nullptr;
+    const float *P_data = nullptr;
+    float *Y_data = nullptr;
+    float *Y_h_data = nullptr;
+    float *Y_c_data = nullptr;
+
+    PPLNN_X86_DEBUG_TRACE("Op: %s\n", GetName().c_str());
+    PPLNN_X86_DEBUG_TRACE("Input [X]:\n");
+    PPL_X86_TENSOR_PRINT_DEBUG_MSG(X);
+    PPLNN_X86_DEBUG_TRACE("Input [W]:\n");
+    PPL_X86_TENSOR_PRINT_DEBUG_MSG(W);
+    PPLNN_X86_DEBUG_TRACE("Input [R]:\n");
+    PPL_X86_TENSOR_PRINT_DEBUG_MSG(R);
+    if (B) {
+        PPLNN_X86_DEBUG_TRACE("Input [B]:\n");
+        PPL_X86_TENSOR_PRINT_DEBUG_MSG(B);
+        B_data = B->GetBufferPtr<const float>();
+    }
+    if (sequence_lens) {
+        PPLNN_X86_DEBUG_TRACE("Input [sequence_lens]:\n");
+        PPL_X86_TENSOR_PRINT_DEBUG_MSG(sequence_lens);
+        sequence_lens_data = sequence_lens->GetBufferPtr<const int32_t>();
+    }
+    if (initial_h) {
+        PPLNN_X86_DEBUG_TRACE("Input [initial_h]:\n");
+        PPL_X86_TENSOR_PRINT_DEBUG_MSG(initial_h);
+        initial_h_data = initial_h->GetBufferPtr<const float>();
+    }
+    if (initial_c) {
+        PPLNN_X86_DEBUG_TRACE("Input [initial_c]:\n");
+        PPL_X86_TENSOR_PRINT_DEBUG_MSG(initial_c);
+        initial_c_data = initial_c->GetBufferPtr<const float>();
+    }
+    if (P) {
+        PPLNN_X86_DEBUG_TRACE("Input [P]:\n");
+        PPL_X86_TENSOR_PRINT_DEBUG_MSG(P);
+        P_data = P->GetBufferPtr<const float>();
+    }
+    if (Y) {
+        PPLNN_X86_DEBUG_TRACE("Output [Y]:\n");
+        PPL_X86_TENSOR_PRINT_DEBUG_MSG(Y);
+        Y_data = Y->GetBufferPtr<float>();
+    }
+    if (Y_h) {
+        PPLNN_X86_DEBUG_TRACE("Output [Y_h]:\n");
+        PPL_X86_TENSOR_PRINT_DEBUG_MSG(Y_h);
+        Y_h_data = Y_h->GetBufferPtr<float>();
+    }
+    if (Y_c) {
+        PPLNN_X86_DEBUG_TRACE("Output [Y_c]:\n");
+        PPL_X86_TENSOR_PRINT_DEBUG_MSG(Y_c);
+        Y_c_data = Y_c->GetBufferPtr<float>();
+    }
+    PPLNN_X86_DEBUG_TRACE("activation_alpha(%lu):\n", param_->activation_alpha.size());
+    for (size_t i = 0; i < param_->activation_alpha.size(); ++i) {
+        PPLNN_X86_DEBUG_TRACE("\t%f\n", param_->activation_alpha[i]);
+    }
+    PPLNN_X86_DEBUG_TRACE("activation_beta(%lu):\n", param_->activation_beta.size());
+    for (size_t i = 0; i < param_->activation_beta.size(); ++i) {
+        PPLNN_X86_DEBUG_TRACE("\t%f\n", param_->activation_beta[i]);
+    }
+    PPLNN_X86_DEBUG_TRACE("activations(%lu):\n", param_->activations.size());
+    for (size_t i = 0; i < param_->activations.size(); ++i) {
+        PPLNN_X86_DEBUG_TRACE("\t%d\n", param_->activations[i]);
+    }
+    PPLNN_X86_DEBUG_TRACE("clip: %f\n", param_->clip);
+    PPLNN_X86_DEBUG_TRACE("direction: %d\n", param_->direction);
+    PPLNN_X86_DEBUG_TRACE("hidden_size: %d\n", param_->hidden_size);
+    PPLNN_X86_DEBUG_TRACE("input_forget: %d\n", param_->input_forget);
+    PPLNN_X86_DEBUG_TRACE("isa: %u\n", GetISA());
+
+    const auto data_type = X->GetShape().GetDataType();
+    const auto data_format = X->GetShape().GetDataFormat();
+
+    if (data_type == ppl::common::DATATYPE_FLOAT32 && data_format == ppl::common::DATAFORMAT_NDARRAY) {
+        return kernel::x86::lstm_ref_fp32(
+            &X->GetShape(), X->GetBufferPtr<const float>(),
+            W->GetBufferPtr<const float>(), R->GetBufferPtr<const float>(),
+            P_data, B_data, sequence_lens_data, initial_h_data, initial_c_data,
+            direction_, param_->hidden_size, tmp_buffer, Y_data, Y_h_data, Y_c_data);
+    } else {
+        LOG(ERROR) << "only support fp32 ndarray now.";
+    }
+
+    return ppl::common::RC_UNSUPPORTED;
+}
+
+}}} // namespace ppl::nn::x86

--- a/src/ppl/nn/engines/x86/kernels/onnx/lstm_kernel.h
+++ b/src/ppl/nn/engines/x86/kernels/onnx/lstm_kernel.h
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef _ST_HPC_PPL_NN_ENGINES_X86_KERNELS_ONNX_LSTM_KERNEL_H_
+#define _ST_HPC_PPL_NN_ENGINES_X86_KERNELS_ONNX_LSTM_KERNEL_H_
+
+#include "ppl/nn/params/onnx/lstm_param.h"
+#include "ppl/nn/engines/x86/kernel.h"
+#include "ppl/kernel/x86/fp32/lstm.h"
+
+namespace ppl { namespace nn { namespace x86 {
+
+class LSTMKernel : public X86Kernel {
+public:
+    LSTMKernel(const ir::Node* node) : X86Kernel(node) {}
+    bool CanDoExecute(const KernelExecContext& ctx) const;
+
+    void SetParam(const ppl::nn::common::LSTMParam* p) {
+        param_ = p;
+        if (p->direction == ppl::nn::common::LSTMParam::DIR_FORWARD) {
+            direction_ = ppl::kernel::x86::rnn_direction::forward;
+        }
+        if (p->direction == ppl::nn::common::LSTMParam::DIR_REVERSE) {
+            direction_ = ppl::kernel::x86::rnn_direction::reverse;
+        }
+        if (p->direction == ppl::nn::common::LSTMParam::DIR_BIDIRECTIONAL) {
+            direction_ = ppl::kernel::x86::rnn_direction::bidirectional;
+        }
+    }
+
+private:
+    uint64_t CalcTmpBufferSize(const KernelExecContext&) const override;
+    ppl::common::RetCode DoExecute(KernelExecContext*) override;
+
+    const ppl::nn::common::LSTMParam* param_ = nullptr;
+    ppl::kernel::x86::rnn_direction_t direction_;
+};
+
+}}} // namespace ppl::nn::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/optimizer/ops/mmcv/mmcv_modulated_deform_conv2d_op.cc
+++ b/src/ppl/nn/engines/x86/optimizer/ops/mmcv/mmcv_modulated_deform_conv2d_op.cc
@@ -15,16 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "ppl/nn/engines/x86/optimizer/ops/mmcv/mmcv_gridsample_op.h"
-#include "ppl/nn/engines/x86/kernels/mmcv/mmcv_gridsample_kernel.h"
-#include "ppl/nn/oputils/mmcv/reshape_mmcv_gridsample.h"
+#include "ppl/nn/engines/x86/optimizer/ops/mmcv/mmcv_modulated_deform_conv2d_op.h"
+#include "ppl/nn/engines/x86/kernels/mmcv/mmcv_modulated_deform_conv2d_kernel.h"
+#include "ppl/nn/oputils/mmcv/reshape_mmcv_modulated_deform_conv2d.h"
 #include "ppl/nn/common/logger.h"
 using namespace std;
 using namespace ppl::common;
 
 namespace ppl { namespace nn { namespace x86 {
 
-RetCode MMCVGridSampleOp::Init(const OptKernelOptions& options) {
+RetCode MMCVModulatedDeformConv2dOp::Init(const OptKernelOptions& options) {
     auto status = GenericLoadParam(options, &param_);
     if (status != RC_SUCCESS) {
         LOG(ERROR) << "load param failed: " << GetRetCodeStr(status);
@@ -32,7 +32,7 @@ RetCode MMCVGridSampleOp::Init(const OptKernelOptions& options) {
     }
 
     infer_dims_func_ = [this](InputOutputInfo* info) -> RetCode {
-        return oputils::ReshapeMMCVGridSample(info, param_.get());
+        return oputils::ReshapeMMCVModulatedDeformConv2d(info, param_.get());
     };
 
     infer_type_func_ = GenericInferType;
@@ -40,8 +40,8 @@ RetCode MMCVGridSampleOp::Init(const OptKernelOptions& options) {
     return RC_SUCCESS;
 }
 
-KernelImpl* MMCVGridSampleOp::CreateKernelImpl() const {
-    return CreateKernelImplWithParam<MMCVGridSampleKernel>(param_.get());
+KernelImpl* MMCVModulatedDeformConv2dOp::CreateKernelImpl() const {
+    return CreateKernelImplWithParam<MMCVModulatedDeformConv2dKernel>(param_.get());
 }
 
 }}} // namespace ppl::nn::x86

--- a/src/ppl/nn/engines/x86/optimizer/ops/mmcv/mmcv_modulated_deform_conv2d_op.h
+++ b/src/ppl/nn/engines/x86/optimizer/ops/mmcv/mmcv_modulated_deform_conv2d_op.h
@@ -15,30 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef _ST_HPC_PPL_NN_PARAMS_ONNX_CONVOLUTION_PARAM_H_
-#define _ST_HPC_PPL_NN_PARAMS_ONNX_CONVOLUTION_PARAM_H_
+#ifndef _ST_HPC_PPL_NN_ENGINES_X86OPTIMIZER_OPS_MMCV_MMCV_MODULATED_DEFORM_CONV2D_OP_H_
+#define _ST_HPC_PPL_NN_ENGINES_X86OPTIMIZER_OPS_MMCV_MMCV_MODULATED_DEFORM_CONV2D_OP_H_
 
-#include <stdint.h>
-#include <vector>
+#include "ppl/nn/params/mmcv/mmcv_modulated_deform_conv2d_param.h"
+#include "ppl/nn/engines/x86/optimizer/opt_kernel.h"
 
-namespace ppl { namespace nn { namespace common {
+namespace ppl { namespace nn { namespace x86 {
 
-struct ConvolutionParam {
-    std::vector<int32_t> kernel_shape;
-    std::vector<int32_t> dilations;
-    std::vector<int32_t> strides;
-    std::vector<int32_t> pads;
+class MMCVModulatedDeformConv2dOp final : public X86OptKernel {
+public:
+    MMCVModulatedDeformConv2dOp(const ir::Node* node) : X86OptKernel(node) {}
+    ppl::common::RetCode Init(const OptKernelOptions& options) override;
+    KernelImpl* CreateKernelImpl() const override;
 
-    int32_t group;
-    int32_t channels; // written in op ctx, for converted filter
-    int32_t num_output; // written in op ctx, for converted filter
-    int32_t bias_term; // written in op ctx, for multi-input layer fusion
-
-    bool operator==(const ConvolutionParam& p) const {
-        return false; // has attr written in op ctx
-    }
+private:
+    std::shared_ptr<ppl::nn::common::MMCVModulatedDeformConv2dParam> param_;
 };
 
-}}} // namespace ppl::nn::common
+}}} // namespace ppl::nn::x86
 
 #endif

--- a/src/ppl/nn/engines/x86/optimizer/ops/onnx/lstm_op.cc
+++ b/src/ppl/nn/engines/x86/optimizer/ops/onnx/lstm_op.cc
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <float.h>
+
+#include "ppl/nn/engines/x86/optimizer/ops/onnx/lstm_op.h"
+#include "ppl/nn/engines/x86/kernels/onnx/lstm_kernel.h"
+#include "ppl/nn/oputils/onnx/reshape_lstm.h"
+#include "ppl/nn/common/logger.h"
+using namespace std;
+using namespace ppl::common;
+
+namespace ppl { namespace nn { namespace x86 {
+
+RetCode LSTMOp::Init(const OptKernelOptions& options) {
+    auto status = GenericLoadParam(options, &param_);
+    if (status != RC_SUCCESS) {
+        LOG(ERROR) << "load param failed: " << GetRetCodeStr(status);
+        return status;
+    }
+
+    if (param_->activations.size() || param_->activation_alpha.size() || param_->activation_beta.size()) {
+        LOG(ERROR) << "LSTM dose not support customize activations and parameters";
+        return ppl::common::RC_UNSUPPORTED;
+    }
+
+    if (param_->clip != FLT_MAX) {
+        LOG(ERROR) << "LSTM dose not support clip";
+        return ppl::common::RC_UNSUPPORTED;
+    }
+
+    if (param_->input_forget) {
+        LOG(ERROR) << "LSTM dose not support input_forget";
+        return ppl::common::RC_UNSUPPORTED;
+    }
+
+    infer_dims_func_ = [this](InputOutputInfo* info) -> RetCode {
+        return oputils::ReshapeLSTM(info, param_.get());
+    };
+
+    infer_type_func_ = GenericInferType;
+
+    return RC_SUCCESS;
+}
+
+KernelImpl* LSTMOp::CreateKernelImpl() const {
+    return CreateKernelImplWithParam<LSTMKernel>(param_.get());
+}
+
+}}} // namespace ppl::nn::x86

--- a/src/ppl/nn/engines/x86/optimizer/ops/onnx/lstm_op.h
+++ b/src/ppl/nn/engines/x86/optimizer/ops/onnx/lstm_op.h
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef _ST_HPC_PPL_NN_ENGINES_X86_OPTIMIZER_OPS_ONNX_LSTM_OP_H_
+#define _ST_HPC_PPL_NN_ENGINES_X86_OPTIMIZER_OPS_ONNX_LSTM_OP_H_
+
+#include "ppl/nn/params/onnx/lstm_param.h"
+#include "ppl/nn/engines/x86/optimizer/opt_kernel.h"
+
+namespace ppl { namespace nn { namespace x86 {
+
+class LSTMOp final : public X86OptKernel {
+public:
+    LSTMOp(const ir::Node* node) : X86OptKernel(node) {}
+    ppl::common::RetCode Init(const OptKernelOptions& options) override;
+    KernelImpl* CreateKernelImpl() const override;
+
+private:
+    std::shared_ptr<ppl::nn::common::LSTMParam> param_;
+};
+
+}}} // namespace ppl::nn::x86
+
+#endif

--- a/src/ppl/nn/engines/x86/optimizer/opt_kernel_creator_manager.cc
+++ b/src/ppl/nn/engines/x86/optimizer/opt_kernel_creator_manager.cc
@@ -87,6 +87,7 @@
 #include "ppl/nn/engines/x86/optimizer/ops/onnx/unsqueeze_op.h"
 #include "ppl/nn/engines/x86/optimizer/ops/onnx/where_op.h"
 #include "ppl/nn/engines/x86/optimizer/ops/mmcv/mmcv_gridsample_op.h"
+#include "ppl/nn/engines/x86/optimizer/ops/mmcv/mmcv_modulated_deform_conv2d_op.h"
 #include "ppl/nn/engines/x86/optimizer/ops/mmcv/mmcv_non_max_suppression_op.h"
 #include "ppl/nn/engines/x86/optimizer/ops/mmcv/mmcv_roialign_op.h"
 #include "ppl/nn/engines/x86/optimizer/ops/ppl/reorder_op.h"
@@ -213,6 +214,7 @@ OptKernelCreatorManager::OptKernelCreatorManager() {
     REGISTER_OPT_KERNEL_CREATOR("mmcv", "grid_sampler", MMCVGridSampleOp);
     REGISTER_OPT_KERNEL_CREATOR("mmcv", "NonMaxSuppression", MMCVNonMaxSuppressionOp);
     REGISTER_OPT_KERNEL_CREATOR("mmcv", "MMCVRoiAlign", MMCVROIAlignOp);
+    REGISTER_OPT_KERNEL_CREATOR("mmcv", "MMCVModulatedDeformConv2d", MMCVModulatedDeformConv2dOp);
 
     // ppl
     REGISTER_OPT_KERNEL_CREATOR("ppl", "ChannelShuffle", ChannelShuffleOp);

--- a/src/ppl/nn/engines/x86/optimizer/opt_kernel_creator_manager.cc
+++ b/src/ppl/nn/engines/x86/optimizer/opt_kernel_creator_manager.cc
@@ -46,6 +46,7 @@
 #include "ppl/nn/engines/x86/optimizer/ops/onnx/less_op.h"
 #include "ppl/nn/engines/x86/optimizer/ops/onnx/log_op.h"
 #include "ppl/nn/engines/x86/optimizer/ops/onnx/loop_op.h"
+#include "ppl/nn/engines/x86/optimizer/ops/onnx/lstm_op.h"
 #include "ppl/nn/engines/x86/optimizer/ops/onnx/matmul_op.h"
 #include "ppl/nn/engines/x86/optimizer/ops/onnx/max_op.h"
 #include "ppl/nn/engines/x86/optimizer/ops/onnx/max_pool_op.h"
@@ -169,6 +170,7 @@ OptKernelCreatorManager::OptKernelCreatorManager() {
     REGISTER_OPT_KERNEL_CREATOR("", "Less", LessOp);
     REGISTER_OPT_KERNEL_CREATOR("", "Log", LogOp);
     REGISTER_OPT_KERNEL_CREATOR("", "Loop", LoopOp);
+    REGISTER_OPT_KERNEL_CREATOR("", "LSTM", LSTMOp);
     REGISTER_OPT_KERNEL_CREATOR("", "MatMul", MatMulOp);
     REGISTER_OPT_KERNEL_CREATOR("", "Max", MaxOp);
     REGISTER_OPT_KERNEL_CREATOR("", "MaxPool", MaxPoolOp);

--- a/src/ppl/nn/models/onnx/param_parser_manager.cc
+++ b/src/ppl/nn/models/onnx/param_parser_manager.cc
@@ -53,6 +53,7 @@
 #include "ppl/nn/models/onnx/parsers/parse_lrn_param.h"
 
 #include "ppl/nn/models/onnx/parsers/parse_mmcv_gridsample_param.h"
+#include "ppl/nn/models/onnx/parsers/parse_mmcv_modulated_deform_conv2d_param.h"
 #include "ppl/nn/models/onnx/parsers/parse_mmcv_nonmaxsupression_param.h"
 #include "ppl/nn/models/onnx/parsers/parse_mmcv_roialign_param.h"
 
@@ -196,6 +197,8 @@ ParamParserManager::ParamParserManager() {
     PPL_REGISTER_OP_WITH_PARAM("mmcv", "NonMaxSuppression", ppl::nn::common::MMCVNMSParam, ParseMMCVNMSParam);
     PPL_REGISTER_OP_WITH_PARAM("mmcv", "MMCVRoiAlign", ppl::nn::common::MMCVROIAlignParam, ParseMMCVROIAlignParam);
     PPL_REGISTER_OP_WITH_PARAM("mmcv", "grid_sampler", ppl::nn::common::MMCVGridSampleParam, ParseMMCVGridSampleParam);
+    PPL_REGISTER_OP_WITH_PARAM("mmcv", "MMCVModulatedDeformConv2d", ppl::nn::common::MMCVModulatedDeformConv2dParam,
+                               ParseMMCVModulatedDeformConv2dParam);
 
     // ppl op param parser
     PPL_REGISTER_OP_WITH_PARAM("ppl", "ChannelShuffle", ppl::nn::common::ChannelShuffleParam, ParseChannelShuffleParam);

--- a/src/ppl/nn/models/onnx/param_parser_manager.cc
+++ b/src/ppl/nn/models/onnx/param_parser_manager.cc
@@ -51,6 +51,7 @@
 #include "ppl/nn/models/onnx/parsers/parse_transpose_param.h"
 #include "ppl/nn/models/onnx/parsers/parse_unsqueeze_param.h"
 #include "ppl/nn/models/onnx/parsers/parse_lrn_param.h"
+#include "ppl/nn/models/onnx/parsers/parse_lstm_param.h"
 
 #include "ppl/nn/models/onnx/parsers/parse_mmcv_gridsample_param.h"
 #include "ppl/nn/models/onnx/parsers/parse_mmcv_modulated_deform_conv2d_param.h"
@@ -192,6 +193,7 @@ ParamParserManager::ParamParserManager() {
     PPL_REGISTER_OP_WITHOUT_PARAM("", "And");
     PPL_REGISTER_OP_WITH_PARAM("", "LRN", ppl::nn::common::LRNParam, ParseLRNParam);
     PPL_REGISTER_OP_WITHOUT_PARAM("", "Dropout");
+    PPL_REGISTER_OP_WITH_PARAM("", "LSTM", ppl::nn::common::LSTMParam, ParseLSTMParam);
 
     // mmcv op param parser
     PPL_REGISTER_OP_WITH_PARAM("mmcv", "NonMaxSuppression", ppl::nn::common::MMCVNMSParam, ParseMMCVNMSParam);

--- a/src/ppl/nn/models/onnx/parsers/parse_convolution_param.cc
+++ b/src/ppl/nn/models/onnx/parsers/parse_convolution_param.cc
@@ -27,6 +27,7 @@ ppl::common::RetCode ParseConvolutionParam(const ::onnx::NodeProto& pb_node, voi
     param->strides = utils::GetNodeAttrsByKey<int32_t>(pb_node, "strides");
     param->pads = utils::GetNodeAttrsByKey<int32_t>(pb_node, "pads");
     param->group = utils::GetNodeAttrByKey(pb_node, "group", 1);
+    param->channels = 0; // set by opcontext
     param->num_output = 0; // set by opcontext
     param->bias_term = 0; // set by opcontext
 

--- a/src/ppl/nn/models/onnx/parsers/parse_lstm_param.cc
+++ b/src/ppl/nn/models/onnx/parsers/parse_lstm_param.cc
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <float.h>
+#include <map>
+
+#include "ppl/nn/models/onnx/parsers/parse_lstm_param.h"
+#include "ppl/nn/common/logger.h"
+#include "ppl/nn/models/onnx/utils.h"
+
+namespace ppl { namespace nn { namespace onnx {
+
+ppl::common::RetCode ParseLSTMParam(const ::onnx::NodeProto& pb_node, void* arg, ir::Node*, ir::GraphTopo*) {
+    auto param = static_cast<ppl::nn::common::LSTMParam*>(arg);
+
+    static const std::map<std::string, ppl::nn::common::LSTMParam::activation_t> act_map = {
+        {"Relu", ppl::nn::common::LSTMParam::ACT_RELU},
+        {"Tanh", ppl::nn::common::LSTMParam::ACT_TANH},
+        {"Sigmoid", ppl::nn::common::LSTMParam::ACT_SIGMOID},
+        {"Affine", ppl::nn::common::LSTMParam::ACT_AFFINE},
+        {"LeakyRelu", ppl::nn::common::LSTMParam::ACT_LEAKY_RELU},
+        {"ThresholdedRelu", ppl::nn::common::LSTMParam::ACT_THRESHOLDED_RELU},
+        {"ScaledTanh", ppl::nn::common::LSTMParam::ACT_SCALED_TANH},
+        {"HardSigmoid", ppl::nn::common::LSTMParam::ACT_HARD_SIGMIOD},
+        {"Elu", ppl::nn::common::LSTMParam::ACT_ELU},
+        {"Softsign", ppl::nn::common::LSTMParam::ACT_SOFTSIGN},
+        {"Softplus", ppl::nn::common::LSTMParam::ACT_SOFTPLUS},
+    };
+
+    static const std::map<std::string, ppl::nn::common::LSTMParam::direction_t> direction_map = {
+        {"forward", ppl::nn::common::LSTMParam::DIR_FORWARD},
+        {"reverse", ppl::nn::common::LSTMParam::DIR_REVERSE},
+        {"bidirectional", ppl::nn::common::LSTMParam::DIR_BIDIRECTIONAL},
+    };
+
+    param->activation_alpha = utils::GetNodeAttrsByKey<float>(pb_node, "activation_alpha");
+    param->activation_beta = utils::GetNodeAttrsByKey<float>(pb_node, "activation_beta");
+
+    auto activations = utils::GetNodeAttrsByKey<std::string>(pb_node, "activations");
+    param->activations.resize(activations.size());
+    for (size_t i = 0; i < activations.size(); ++i) {
+        auto it = act_map.find(activations[i]);
+        if (it == act_map.end()) {
+            LOG(ERROR) << "Unsupported activation type: " << activations[i];
+        }
+        param->activations[i] = it->second;
+    }
+
+    param->clip = utils::GetNodeAttrByKey<float>(pb_node, "clip", FLT_MAX);
+
+    auto direction = utils::GetNodeAttrByKey<std::string>(pb_node, "direction", "forward");
+    {
+        auto it = direction_map.find(direction);
+        if (it == direction_map.end()) {
+            LOG(ERROR) << "Unsupported direction type: " << direction;
+        }
+        param->direction = it->second;
+    }
+
+    param->hidden_size = utils::GetNodeAttrByKey<int32_t>(pb_node, "hidden_size", INT32_MIN);
+    if (param->hidden_size == INT32_MIN) {
+        LOG(ERROR) << "hidden_size is not set but required";
+        return ppl::common::RC_INVALID_VALUE;
+    }
+
+    param->input_forget = utils::GetNodeAttrByKey<int32_t>(pb_node, "input_forget", 0);
+
+    return ppl::common::RC_SUCCESS;
+}
+
+}}} // namespace ppl::nn::onnx

--- a/src/ppl/nn/models/onnx/parsers/parse_lstm_param.h
+++ b/src/ppl/nn/models/onnx/parsers/parse_lstm_param.h
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef _ST_HPC_PPL_NN_MODELS_ONNX_PARSERS_PARSE_LSTM_PARAM_H_
+#define _ST_HPC_PPL_NN_MODELS_ONNX_PARSERS_PARSE_LSTM_PARAM_H_
+
+#include "ppl/common/retcode.h"
+#include "ppl/nn/params/onnx/lstm_param.h"
+#include "ppl/nn/ir/graph.h"
+#include "ppl/nn/models/onnx/generated/onnx.pb.h"
+
+namespace ppl { namespace nn { namespace onnx {
+
+ppl::common::RetCode ParseLSTMParam(const ::onnx::NodeProto& pb_node, void* arg, ir::Node*, ir::GraphTopo*);
+
+}}} // namespace ppl::nn::onnx
+
+#endif

--- a/src/ppl/nn/models/onnx/parsers/parse_mmcv_modulated_deform_conv2d_param.cc
+++ b/src/ppl/nn/models/onnx/parsers/parse_mmcv_modulated_deform_conv2d_param.cc
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/nn/models/onnx/parsers/parse_mmcv_modulated_deform_conv2d_param.h"
+#include "ppl/nn/models/onnx/utils.h"
+
+namespace ppl { namespace nn { namespace onnx {
+
+ppl::common::RetCode ParseMMCVModulatedDeformConv2dParam(const ::onnx::NodeProto& pb_node, void* arg, ir::Node*, ir::GraphTopo*) {
+    auto param = static_cast<ppl::nn::common::MMCVModulatedDeformConv2dParam*>(arg);
+
+    param->kernel_size[0] = 0; // set by opcontext, for converted filter
+    param->kernel_size[1] = 0; // set by opcontext, for converted filter
+    param->channels = 0; // set by opcontext, for converted filter
+    param->num_output = 0; // set by opcontext, for converted filter
+    param->bias_term = 0; // set by opcontext, for multi-input layer fusion
+
+    param->groups = utils::GetNodeAttrByKey(pb_node, "groups", 1);
+    param->deform_groups = utils::GetNodeAttrByKey(pb_node, "deform_groups", 1);
+
+    auto stride = utils::GetNodeAttrsByKey<int32_t>(pb_node, "stride");
+    auto padding = utils::GetNodeAttrsByKey<int32_t>(pb_node, "padding");
+    auto dilation = utils::GetNodeAttrsByKey<int32_t>(pb_node, "dilation");
+
+    auto kernel_dims = 2;
+
+    if (dilation.size() != kernel_dims || stride.size() != kernel_dims || padding.size() != kernel_dims) {
+        return ppl::common::RC_INVALID_VALUE;
+    }
+
+    param->stride[0] = stride[0];
+    param->stride[1] = stride[1];
+
+    param->padding[0] = padding[0];
+    param->padding[1] = padding[1];
+
+    param->dilation[0] = dilation[0];
+    param->dilation[1] = dilation[1];
+
+    return ppl::common::RC_SUCCESS;
+}
+
+}}} // namespace ppl::nn::onnx

--- a/src/ppl/nn/models/onnx/parsers/parse_mmcv_modulated_deform_conv2d_param.cc
+++ b/src/ppl/nn/models/onnx/parsers/parse_mmcv_modulated_deform_conv2d_param.cc
@@ -36,7 +36,7 @@ ppl::common::RetCode ParseMMCVModulatedDeformConv2dParam(const ::onnx::NodeProto
     auto padding = utils::GetNodeAttrsByKey<int32_t>(pb_node, "padding");
     auto dilation = utils::GetNodeAttrsByKey<int32_t>(pb_node, "dilation");
 
-    auto kernel_dims = 2;
+    size_t kernel_dims = 2;
 
     if (dilation.size() != kernel_dims || stride.size() != kernel_dims || padding.size() != kernel_dims) {
         return ppl::common::RC_INVALID_VALUE;

--- a/src/ppl/nn/models/onnx/parsers/parse_mmcv_modulated_deform_conv2d_param.h
+++ b/src/ppl/nn/models/onnx/parsers/parse_mmcv_modulated_deform_conv2d_param.h
@@ -15,30 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef _ST_HPC_PPL_NN_PARAMS_ONNX_CONVOLUTION_PARAM_H_
-#define _ST_HPC_PPL_NN_PARAMS_ONNX_CONVOLUTION_PARAM_H_
+#ifndef _ST_HPC_PPL_NN_MODELS_ONNX_PARSERS_PARSE_MMCV_MODULATED_DEFORM_CONV2D_PARAM_H_
+#define _ST_HPC_PPL_NN_MODELS_ONNX_PARSERS_PARSE_MMCV_MODULATED_DEFORM_CONV2D_PARAM_H_
 
-#include <stdint.h>
-#include <vector>
+#include "ppl/common/retcode.h"
+#include "ppl/nn/params/mmcv/mmcv_modulated_deform_conv2d_param.h"
+#include "ppl/nn/ir/graph.h"
+#include "ppl/nn/models/onnx/generated/onnx.pb.h"
 
-namespace ppl { namespace nn { namespace common {
+namespace ppl { namespace nn { namespace onnx {
 
-struct ConvolutionParam {
-    std::vector<int32_t> kernel_shape;
-    std::vector<int32_t> dilations;
-    std::vector<int32_t> strides;
-    std::vector<int32_t> pads;
+ppl::common::RetCode ParseMMCVModulatedDeformConv2dParam(const ::onnx::NodeProto& pb_node, void* arg, ir::Node*, ir::GraphTopo*);
 
-    int32_t group;
-    int32_t channels; // written in op ctx, for converted filter
-    int32_t num_output; // written in op ctx, for converted filter
-    int32_t bias_term; // written in op ctx, for multi-input layer fusion
-
-    bool operator==(const ConvolutionParam& p) const {
-        return false; // has attr written in op ctx
-    }
-};
-
-}}} // namespace ppl::nn::common
+}}} // namespace ppl::nn::onnx
 
 #endif

--- a/src/ppl/nn/models/onnx/utils.cc
+++ b/src/ppl/nn/models/onnx/utils.cc
@@ -39,6 +39,38 @@ vector<int32_t> GetNodeAttrsByKey<int32_t>(const ::onnx::NodeProto& node, const 
 }
 
 template <>
+vector<float> GetNodeAttrsByKey<float>(const ::onnx::NodeProto& node, const char* key) {
+    vector<float> result;
+    for (int32_t i = 0; i < node.attribute_size(); i++) {
+        const ::onnx::AttributeProto& attribute = node.attribute(i);
+        if (attribute.name() == key) {
+            result.resize(attribute.floats_size());
+            for (int32_t j = 0; j < attribute.floats_size(); j++) {
+                result[j] = attribute.floats(j);
+            }
+            break;
+        }
+    }
+    return result;
+}
+
+template <>
+vector<string> GetNodeAttrsByKey<string>(const ::onnx::NodeProto& node, const char* key) {
+    vector<string> result;
+    for (int32_t i = 0; i < node.attribute_size(); i++) {
+        const ::onnx::AttributeProto& attribute = node.attribute(i);
+        if (attribute.name() == key) {
+            result.resize(attribute.strings_size());
+            for (int32_t j = 0; j < attribute.strings_size(); j++) {
+                result[j] = attribute.strings(j);
+            }
+            break;
+        }
+    }
+    return result;
+}
+
+template <>
 int32_t GetAttrValue<int32_t>(const ::onnx::AttributeProto& attribute) {
     return attribute.i();
 }

--- a/src/ppl/nn/oputils/mmcv/reshape_mmcv_modulated_deform_conv2d.h
+++ b/src/ppl/nn/oputils/mmcv/reshape_mmcv_modulated_deform_conv2d.h
@@ -15,30 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef _ST_HPC_PPL_NN_PARAMS_ONNX_CONVOLUTION_PARAM_H_
-#define _ST_HPC_PPL_NN_PARAMS_ONNX_CONVOLUTION_PARAM_H_
+#ifndef _ST_HPC_PPL_NN_OPUTILS_MMCV_RESHAPE_MMCV_MODULATED_DEFORM_CONV2D_H_
+#define _ST_HPC_PPL_NN_OPUTILS_MMCV_RESHAPE_MMCV_MODULATED_DEFORM_CONV2D_H_
 
-#include <stdint.h>
-#include <vector>
+#include "ppl/common/retcode.h"
+#include "ppl/nn/params/mmcv/mmcv_modulated_deform_conv2d_param.h"
+#include "ppl/nn/common/input_output_info.h"
 
-namespace ppl { namespace nn { namespace common {
+namespace ppl { namespace nn { namespace oputils {
 
-struct ConvolutionParam {
-    std::vector<int32_t> kernel_shape;
-    std::vector<int32_t> dilations;
-    std::vector<int32_t> strides;
-    std::vector<int32_t> pads;
+ppl::common::RetCode ReshapeMMCVModulatedDeformConv2d(InputOutputInfo*, const void*);
 
-    int32_t group;
-    int32_t channels; // written in op ctx, for converted filter
-    int32_t num_output; // written in op ctx, for converted filter
-    int32_t bias_term; // written in op ctx, for multi-input layer fusion
-
-    bool operator==(const ConvolutionParam& p) const {
-        return false; // has attr written in op ctx
-    }
-};
-
-}}} // namespace ppl::nn::common
+}}} // namespace ppl::nn::oputils
 
 #endif

--- a/src/ppl/nn/oputils/onnx/reshape_lstm.cc
+++ b/src/ppl/nn/oputils/onnx/reshape_lstm.cc
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "ppl/nn/oputils/onnx/reshape_lstm.h"
+#include "ppl/nn/runtime/tensor_impl.h"
+using namespace ppl::common;
+using namespace ppl::nn::common;
+
+namespace ppl { namespace nn { namespace oputils {
+
+RetCode ReshapeLSTM(InputOutputInfo* info, const void* arg) {
+    auto param = (const LSTMParam*)arg;
+    const TensorShape& in_shape = info->GetInput<TensorImpl>(0)->GetShape();
+    const int64_t seq_len = in_shape.GetDim(0);
+    const int64_t batch = in_shape.GetDim(1);
+    const int64_t num_directions = param->direction == LSTMParam::DIR_BIDIRECTIONAL ? 2 : 1;
+
+    if (info->GetOutputCount() > 0) {
+        info->GetOutput<TensorImpl>(0)->GetShape().Reshape({seq_len, num_directions, batch, param->hidden_size});
+    }
+    if (info->GetOutputCount() > 1) {
+        info->GetOutput<TensorImpl>(1)->GetShape().Reshape({num_directions, batch, param->hidden_size});
+    }
+    if (info->GetOutputCount() > 2) {
+        info->GetOutput<TensorImpl>(2)->GetShape().Reshape({num_directions, batch, param->hidden_size});
+    }
+
+    return RC_SUCCESS;
+}
+
+}}} // namespace ppl::nn::oputils

--- a/src/ppl/nn/oputils/onnx/reshape_lstm.h
+++ b/src/ppl/nn/oputils/onnx/reshape_lstm.h
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef _ST_HPC_PPL_NN_OPUTILS_ONNX_RESHAPE_LSTM_H_
+#define _ST_HPC_PPL_NN_OPUTILS_ONNX_RESHAPE_LSTM_H_
+
+#include "ppl/common/retcode.h"
+#include "ppl/nn/params/onnx/lstm_param.h"
+#include "ppl/nn/common/input_output_info.h"
+
+namespace ppl { namespace nn { namespace oputils {
+
+ppl::common::RetCode ReshapeLSTM(InputOutputInfo*, const void*);
+
+}}} // namespace ppl::nn::oputils
+
+#endif

--- a/src/ppl/nn/params/mmcv/mmcv_modulated_deform_conv2d_param.h
+++ b/src/ppl/nn/params/mmcv/mmcv_modulated_deform_conv2d_param.h
@@ -15,26 +15,26 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef _ST_HPC_PPL_NN_PARAMS_ONNX_CONVOLUTION_PARAM_H_
-#define _ST_HPC_PPL_NN_PARAMS_ONNX_CONVOLUTION_PARAM_H_
+#ifndef _ST_HPC_PPL_NN_PARAMS_MMCV_MMCV_MODULATED_DEFORM_CONV2D_PARAM_H
+#define _ST_HPC_PPL_NN_PARAMS_MMCV_MMCV_MODULATED_DEFORM_CONV2D_PARAM_H
 
 #include <stdint.h>
-#include <vector>
 
 namespace ppl { namespace nn { namespace common {
 
-struct ConvolutionParam {
-    std::vector<int32_t> kernel_shape;
-    std::vector<int32_t> dilations;
-    std::vector<int32_t> strides;
-    std::vector<int32_t> pads;
+struct MMCVModulatedDeformConv2dParam {
+    int64_t kernel_size[2]; // written in op ctx
+    int64_t stride[2];
+    int64_t padding[2];
+    int64_t dilation[2];
+    int64_t groups;
+    int64_t deform_groups;
 
-    int32_t group;
-    int32_t channels; // written in op ctx, for converted filter
-    int32_t num_output; // written in op ctx, for converted filter
-    int32_t bias_term; // written in op ctx, for multi-input layer fusion
+    int64_t channels;  // written in op ctx
+    int64_t num_output; // written in op ctx
+    int64_t bias_term; // written in op ctx, for multi-input layer fusion
 
-    bool operator==(const ConvolutionParam& p) const {
+    bool operator==(const MMCVModulatedDeformConv2dParam& p) const {
         return false; // has attr written in op ctx
     }
 };

--- a/src/ppl/nn/params/onnx/lstm_param.h
+++ b/src/ppl/nn/params/onnx/lstm_param.h
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef _ST_HPC_PPL_NN_PARAMS_ONNX_LSTM_PARAM_H_
+#define _ST_HPC_PPL_NN_PARAMS_ONNX_LSTM_PARAM_H_
+
+#include <stdint.h>
+#include <vector>
+#include <string>
+
+namespace ppl { namespace nn { namespace common {
+
+struct LSTMParam {
+    typedef enum {
+        ACT_RELU = 0,
+        ACT_TANH,
+        ACT_SIGMOID,
+        ACT_AFFINE,
+        ACT_LEAKY_RELU,
+        ACT_THRESHOLDED_RELU,
+        ACT_SCALED_TANH,
+        ACT_HARD_SIGMIOD,
+        ACT_ELU,
+        ACT_SOFTSIGN,
+        ACT_SOFTPLUS
+    } activation_t;
+
+    typedef enum {
+        DIR_FORWARD = 0,
+        DIR_REVERSE,
+        DIR_BIDIRECTIONAL,
+    } direction_t;
+
+    std::vector<float> activation_alpha;
+    std::vector<float> activation_beta;
+    std::vector<activation_t> activations;
+    float clip;
+    direction_t direction;
+    int32_t hidden_size;
+    int32_t input_forget;
+
+    bool operator==(const LSTMParam& p) const {
+        const bool val_eq =
+            this->direction == p.direction &&
+            this->hidden_size == p.hidden_size &&
+            this->input_forget == p.input_forget &&
+            this->clip == p.clip;
+        bool list_eq =
+            this->activation_alpha.size() == p.activation_alpha.size() &&
+            this->activation_beta.size() == p.activation_beta.size() &&
+            this->activations.size() == p.activations.size();
+        if (list_eq) {
+            for (size_t i = 0; i < this->activation_alpha.size(); ++i) {
+                if (this->activation_alpha[i] != p.activation_alpha[i]) {
+                    list_eq = false;
+                    goto _LABEL_onnx_lstm_param_exit_list_cmp;
+                }
+            }
+            for (size_t i = 0; i < this->activation_beta.size(); ++i) {
+                if (this->activation_beta[i] != p.activation_beta[i]) {
+                    list_eq = false;
+                    goto _LABEL_onnx_lstm_param_exit_list_cmp;
+                }
+            }
+            for (size_t i = 0; i < this->activations.size(); ++i) {
+                if (this->activations[i] != p.activations[i]) {
+                    list_eq = false;
+                    goto _LABEL_onnx_lstm_param_exit_list_cmp;
+                }
+            }
+        }
+_LABEL_onnx_lstm_param_exit_list_cmp:
+        return list_eq && val_eq;
+    }
+};
+
+}}} // namespace ppl::nn::common
+
+#endif


### PR DESCRIPTION
 - mmcv.MMCVDeformConv2d reference version (non-optimized)
 - onnx.LSTM reference version (non-optimized)
 - onnx.Softmax float point overflow bug fix
 - mmcv.grid_sampler kernel select fix