### PR TITLE
[fix] python compilation error on Darwin and use '.so' to replace '.d…

### DIFF
--- a/build-for-test.sh
+++ b/build-for-test.sh
@@ -3,7 +3,14 @@
 workdir=`pwd`
 x86_64_build_dir="${workdir}/x86-64-build"
 cuda_build_dir="${workdir}/cuda-build"
-processor_num=`cat /proc/cpuinfo | grep processor | grep -v grep | wc -l`
+
+if [[ `uname` == "Linux" ]]; then
+    processor_num=`cat /proc/cpuinfo | grep processor | grep -v grep | wc -l`
+elif [[ `uname` == "Darwin" ]]; then
+    processor_num=`sysctl machdep.cpu | grep machdep.cpu.core_count | cut -d " " -f 2`
+else
+    processor_num=1
+fi
 
 options='-DCMAKE_BUILD_TYPE=Release -DPPLNN_ENABLE_PYTHON_API=ON'
 

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -64,7 +64,7 @@ set(PPLCOMMON_ENABLE_LUA_API ${PPLNN_ENABLE_LUA_API})
 
 hpcc_declare_git_dep(ppl.common
     https://github.com/openppl-public/ppl.common.git
-    afd0d6c90accbeb3e73fedd7b6c983e906546f7e)
+    ec3d5cdda45097b569160603ff52b3a1f129b711)
 
 # --------------------------------------------------------------------------- #
 

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -21,6 +21,10 @@ target_include_directories(luapplnn_shared PUBLIC
 set_target_properties(luapplnn_shared PROPERTIES PREFIX "")
 set_target_properties(luapplnn_shared PROPERTIES OUTPUT_NAME "nn")
 
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+    set_target_properties(luapplnn_shared PROPERTIES SUFFIX ".so") # using .so instead of .dylib
+endif()
+
 if(PPLNN_INSTALL)
     install(TARGETS luapplnn_shared DESTINATION luappl)
 endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -36,6 +36,11 @@ target_compile_features(pypplnn_shared PRIVATE cxx_std_11)
 set_target_properties(pypplnn_shared PROPERTIES PREFIX "")
 set_target_properties(pypplnn_shared PROPERTIES OUTPUT_NAME "nn")
 
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
+    target_link_options(pypplnn_shared PUBLIC "LINKER:-undefined,dynamic_lookup") # required by pybind11
+    set_target_properties(pypplnn_shared PROPERTIES SUFFIX ".so") # using .so instead of .dylib
+endif()
+
 if(PPLNN_INSTALL)
     install(TARGETS pypplnn_shared DESTINATION pyppl)
 endif()


### PR DESCRIPTION
…ylib' for python and lua libraries