### PR TITLE
fix bugs when build on Windows VS2019

### DIFF
--- a/src/ppl/nn/engines/cuda/cuda_common.h
+++ b/src/ppl/nn/engines/cuda/cuda_common.h
@@ -21,7 +21,7 @@
 #if defined(__linux__)
 #include <sys/stat.h>
 
-#elif defined(__Win32) // defined(__Win32__) // defined(Win32)
+#elif defined(__Win32) || defined(__Win32__) || defined(Win32)
 #include<iostream> 
 #endif
 

--- a/src/ppl/nn/engines/cuda/cuda_common.h
+++ b/src/ppl/nn/engines/cuda/cuda_common.h
@@ -20,6 +20,9 @@
 
 #if defined(__linux__)
 #include <sys/stat.h>
+
+#elif defined(__Win32) // defined(__Win32__) // defined(Win32)
+#include<iostream> 
 #endif
 
 #include <map>


### PR DESCRIPTION
solved a problem when build on windows by visual studio 2019.
add #elif defined to include <iostream> on windows.
