### PR TITLE
[refactor] use shared_ptr to initialize PyEngine so that external eng…

### DIFF
--- a/python/engines/cuda/py_cuda_engine.h
+++ b/python/engines/cuda/py_cuda_engine.h
@@ -25,6 +25,9 @@ namespace ppl { namespace nn { namespace python {
 
 struct PyCudaEngine final {
     PyCudaEngine(Engine* p) : ptr(p) {}
+    operator std::shared_ptr<Engine> () const {
+        return ptr;
+    }
     std::shared_ptr<Engine> ptr;
 };
 

--- a/python/engines/py_engine.cc
+++ b/python/engines/py_engine.cc
@@ -23,15 +23,7 @@ namespace ppl { namespace nn { namespace python {
 
 void RegisterEngine(pybind11::module* m) {
     pybind11::class_<PyEngine>(*m, "Engine")
-#ifdef PPLNN_USE_X86
-        .def(pybind11::init<PyX86Engine>())
-#endif
-#ifdef PPLNN_USE_CUDA
-        .def(pybind11::init<PyCudaEngine>())
-#endif
-#ifdef PPLNN_USE_RISCV
-        .def(pybind11::init<PyRiscvEngine>())
-#endif
+        .def(pybind11::init<std::shared_ptr<Engine>>())
         .def("__bool__", [](const PyEngine& engine) -> bool {
             return (engine.ptr.get());
         });

--- a/python/engines/py_engine.h
+++ b/python/engines/py_engine.h
@@ -21,34 +21,10 @@
 #include "ppl/nn/engines/engine.h"
 #include <memory>
 
-#ifdef PPLNN_USE_X86
-#include "x86/py_x86_engine.h"
-#endif
-#ifdef PPLNN_USE_CUDA
-#include "cuda/py_cuda_engine.h"
-#endif
-#ifdef PPLNN_USE_RISCV
-#include "riscv/py_riscv_engine.h"
-#endif
-
 namespace ppl { namespace nn { namespace python {
 
 struct PyEngine final {
-#ifdef PPLNN_USE_X86
-    PyEngine(const PyX86Engine& e) {
-        ptr = e.ptr;
-    }
-#endif
-#ifdef PPLNN_USE_CUDA
-    PyEngine(const PyCudaEngine& e) {
-        ptr = e.ptr;
-    }
-#endif
-#ifdef PPLNN_USE_RISCV
-    PyEngine(const PyRiscvEngine& e) {
-        ptr = e.ptr;
-    }
-#endif
+    PyEngine(const std::shared_ptr<Engine>& e) : ptr(e) {}
     std::shared_ptr<Engine> ptr;
 };
 

--- a/python/engines/riscv/py_riscv_engine.h
+++ b/python/engines/riscv/py_riscv_engine.h
@@ -25,6 +25,9 @@ namespace ppl { namespace nn { namespace python {
 
 struct PyRiscvEngine final {
     PyRiscvEngine(Engine* p) : ptr(p) {}
+    operator std::shared_ptr<Engine> () const {
+        return ptr;
+    }
     std::shared_ptr<Engine> ptr;
 };
 

--- a/python/engines/x86/py_x86_engine.h
+++ b/python/engines/x86/py_x86_engine.h
@@ -25,6 +25,9 @@ namespace ppl { namespace nn { namespace python {
 
 struct PyX86Engine final {
     PyX86Engine(Engine* p) : ptr(p) {}
+    operator std::shared_ptr<Engine> () const {
+        return ptr;
+    }
     std::shared_ptr<Engine> ptr;
 };
 


### PR DESCRIPTION
…ines can register to nn module