### PR TITLE
[misc] remove non-empty buffer checking when setting device for `Buff…

### DIFF
--- a/src/ppl/nn/common/buffer_info.cc
+++ b/src/ppl/nn/common/buffer_info.cc
@@ -53,10 +53,6 @@ BufferInfo& BufferInfo::operator=(BufferInfo&& info) {
 }
 
 RetCode BufferInfo::SetDevice(Device* dev) {
-    if (buffer_.addr) {
-        LOG(ERROR) << "BufferInfo::SetDevice() failed: buffer is not empty";
-        return RC_PERMISSION_DENIED;
-    }
     if (!dev) {
         LOG(ERROR) << "SetDevice failed: device is empty.";
         return RC_INVALID_VALUE;

--- a/tests/common/tensor_buffer_info_test.cc
+++ b/tests/common/tensor_buffer_info_test.cc
@@ -35,7 +35,7 @@ TEST(TensorBufferInfoTest, with_buffer) {
     utils::GenericCpuDevice device;
     auto info = GenRandomTensorBufferInfo(&device);
     EXPECT_EQ(&device, info.GetDevice());
-    EXPECT_NE(RC_SUCCESS, info.SetDevice(&device)); // cannot set device if buffer is not empty
+    EXPECT_EQ(RC_SUCCESS, info.SetDevice(&device)); // set device even if buffer is not empty
     info.FreeBuffer();
 }
 

--- a/tests/runtime/tensor_impl_test.cc
+++ b/tests/runtime/tensor_impl_test.cc
@@ -74,7 +74,7 @@ TEST_F(TensorImplTest, empty) {
 TEST_F(TensorImplTest, with_buffer) {
     auto tensor = ConstructFp32TensorWithCpuDevice();
     EXPECT_EQ(RC_SUCCESS, tensor.ReallocBuffer());
-    EXPECT_NE(RC_SUCCESS, tensor.SetDevice(&cpu_device_)); // cannot set device if buffer is not empty
+    EXPECT_EQ(RC_SUCCESS, tensor.SetDevice(&cpu_device_)); // set device even if buffer is not empty
     tensor.FreeBuffer();
 }
 


### PR DESCRIPTION
…erInfo`