### PR TITLE
[x86] `Floor` `Softmax` Opset fix

### DIFF
--- a/docs/en/x86-doc/supported-ops-and-platforms.md
+++ b/docs/en/x86-doc/supported-ops-and-platforms.md
@@ -31,7 +31,7 @@ x86 only supports FP32 precision on AVX512/FMA.
 | Exp                | 6~16   | &check;                     |
 | Expand             | 8~16   | &check;                     |
 | Flatten            | 1~16   | &check;                     |
-| Floor              | 16~16  | &check;                     |
+| Floor              | 6~16   | &check;                     |
 | Gather             | 1~16   | &check;                     |
 | GatherND           | 11     | &check;                     |
 | Gemm               | 9~16   | &check;                     |
@@ -73,7 +73,7 @@ x86 only supports FP32 precision on AVX512/FMA.
 | Sigmoid            | 6~16   | &check;                     |
 | Sin                | 7~16   | &check;                     |
 | Slice              | 1~16   | &check;                     |
-| Softmax            | 1~16   | &check;                     |
+| Softmax            | 1~12   | &check;                     |
 | Split              | 2~12   | &check;                     |
 | SplitToSequence    | 11~16  | &check;                     |
 | Sqrt               | 6~16   | &check;                     |

--- a/src/ppl/nn/engines/x86/optimizer/x86_ops.cc
+++ b/src/ppl/nn/engines/x86/optimizer/x86_ops.cc
@@ -203,7 +203,7 @@ void RegisterBuiltinOpImpls() {
     RegisterOptKernelCreator<SigmoidOp>("", "Sigmoid", 6, 16);
     RegisterOptKernelCreator<SinOp>("", "Sin", 7, 16);
     RegisterOptKernelCreator<SliceOp>("", "Slice", 1, 16);
-    RegisterOptKernelCreator<SoftmaxOp>("", "Softmax", 1, 16);
+    RegisterOptKernelCreator<SoftmaxOp>("", "Softmax", 1, 12);
     RegisterOptKernelCreator<SplitOp>("", "Split", 2, 12);
     RegisterOptKernelCreator<SplitToSequenceOp>("", "SplitToSequence", 11, 16);
     RegisterOptKernelCreator<SqrtOp>("", "Sqrt", 6, 16);


### PR DESCRIPTION
Parameter of `Softmax` did not change in opset13, but it's algorithm was not as opset1-12