### PR TITLE
[cuda][mod]: add datatype judge for fp16-only algos

### DIFF
--- a/src/ppl/nn/engines/cuda/optimizer/algos/algo_conv_hmma.cc
+++ b/src/ppl/nn/engines/cuda/optimizer/algos/algo_conv_hmma.cc
@@ -19,7 +19,6 @@
 
 #include <chrono>
 
-
 #include "ppl/common/cuda/cuda_types.h"
 #include "ppl/nn/common/logger.h"
 #include "ppl/nn/utils/utils.h"
@@ -44,7 +43,11 @@ bool TuringHMMAImpgemm::IsSupported(const ir::Node* node, const OptKernelOptions
                                     dataformat_t input_format) const {
     uint32_t group = (reinterpret_cast<CudaConvParam*>(options.param))->param.group;
     // check if conv is depthwise
+    const TensorShape& tensor0 = *options.tensors->find(node->GetInput(0))->second->GetShape();
     const TensorShape& tensor1 = *options.tensors->find(node->GetInput(1))->second->GetShape();
+    if (tensor0.GetDataType() != ppl::common::DATATYPE_FLOAT16) {
+        return false;
+    }
     if (group == tensor1.GetDim(0) && tensor1.GetDim(1) == 1 && group != 1) {
         return false;
     }
@@ -138,8 +141,8 @@ double TuringHMMAImpgemm::ExcuteTimer(const ir::Node* node, OptKernelOptions& op
                                                 attr_param_.extra_param.algo_info, temp_conv_param, temp_fuse_param);
 #endif
     CudaArgs::AlgoSelects algo_select;
-    algo_select.kname  = attr_param_.extra_param.algo_info.algo_name;
-    algo_select.kid    = attr_param_.extra_param.algo_info.kid;
+    algo_select.kname = attr_param_.extra_param.algo_info.algo_name;
+    algo_select.kid = attr_param_.extra_param.algo_info.kid;
     algo_select.splitk = attr_param_.extra_param.algo_info.splitk;
     algo_select.splitf = attr_param_.extra_param.algo_info.splitf;
     options.algos->emplace(key_str, std::move(algo_select));

--- a/src/ppl/nn/engines/cuda/optimizer/algos/algo_gemm.h
+++ b/src/ppl/nn/engines/cuda/optimizer/algos/algo_gemm.h
@@ -33,6 +33,8 @@ public:
         gemm_formats_.emplace(DATAFORMAT_NHWC8, nhwc8);
         std::set<dataformat_t> nhwc16{DATAFORMAT_NHWC16};
         gemm_formats_.emplace(DATAFORMAT_NHWC16, nhwc16);
+        std::set<dataformat_t> nchw{DATAFORMAT_NDARRAY};
+        gemm_formats_.emplace(DATAFORMAT_NDARRAY, nchw);
     }
 
     const std::map<dataformat_t, std::set<dataformat_t>> Getformats(const std::string& type_name) const override {
@@ -42,8 +44,7 @@ public:
 public:
     void GetAttrParam(void*& param) const override;
     void DeleteAttrParam(void*& param) override;
-    bool IsSupported(const ir::Node* node, const OptKernelOptions& options,
-                     dataformat_t input_format) const override;
+    bool IsSupported(const ir::Node* node, const OptKernelOptions& options, dataformat_t input_format) const override;
     double ExcuteTimer(const ir::Node* node, OptKernelOptions& options) override;
     RetCode ModifyParam(ir::Node* node, OptKernelOptions& options) override;
     void ReshapeOnEdges(const ir::Node* node, std::map<edgeid_t, std::unique_ptr<TensorImpl>>* tensors,


### PR DESCRIPTION
when run fp32-kernel-datatype, some errors occur in gemm and conv algos. So add datatype judge.