### PR TITLE
[cuda][fix]: host half cvt support from cuda9_2

### DIFF
--- a/src/ppl/nn/engines/cuda/impls/src/nn/conv/conv_fp16.cu
+++ b/src/ppl/nn/engines/cuda/impls/src/nn/conv/conv_fp16.cu
@@ -366,6 +366,7 @@ double PPLCUDAConvolutionSelectKernel(
     fuse_param_t &fuse_param,
     uint64_t workspace)
 {
+#if __CUDACC_VER_MAJOR__ * 1000 + __CUDACC_VER_MINOR__ * 10 >= 9020
     cudaDeviceProp device_prop;
     cudaGetDeviceProperties(&device_prop, device_id);
 
@@ -582,6 +583,9 @@ double PPLCUDAConvolutionSelectKernel(
 
     g_conv_shape_hash[conv_shape_hash] = algo_param;
     return minTime;
+#else
+    return 0.0;
+#endif
 }
 
 void PPLCUDAConvolutionForwardImp(
@@ -597,6 +601,7 @@ void PPLCUDAConvolutionForwardImp(
     conv_param_t &conv_param,
     fuse_param_t &fuse_param)
 {
+#if __CUDACC_VER_MAJOR__ * 1000 + __CUDACC_VER_MINOR__ * 10 >= 9020
     if (!is_g_fp16_kvec_initialized)
         InitializeFP16ConvKernelContainer(g_fp16_kvec, device_id, type);
 
@@ -742,6 +747,7 @@ void PPLCUDAConvolutionForwardImp(
     if (is_out_grp_pad) {
         PPLCUDAConvolutionCvtOutput(stream, d_output, final_out, type, conv_param);
     }
+#endif
 }
 
 void kernel_info_t::AdaptLutKernelSMemSize()
@@ -1445,6 +1451,7 @@ void PPLCUDAConvolutionForwardJitImp(
     conv_param_t &conv_param,
     fuse_param_t &fuse_param)
 {
+#if __CUDACC_VER_MAJOR__ * 1000 + __CUDACC_VER_MINOR__ * 10 >= 9020
 #ifdef PPLNN_ENABLE_CUDA_JIT
     unsigned int splitk = algo_param.splitk;
     unsigned int splitf = algo_param.splitf;
@@ -1594,5 +1601,6 @@ void PPLCUDAConvolutionForwardJitImp(
     if (is_out_grp_pad) {
         PPLCUDAConvolutionCvtOutput(stream, d_output, final_out, type, conv_param);
     }
+#endif
 #endif
 }

--- a/src/ppl/nn/engines/cuda/impls/src/nn/gemm_int8.cu
+++ b/src/ppl/nn/engines/cuda/impls/src/nn/gemm_int8.cu
@@ -466,7 +466,7 @@ __device__ __inline__ void fma_v4(const int4 a, const int4 b, int4 &c);
 template <>
 __device__ __inline__ void fma_v4<int8_t>(const int4 a, const int4 b, int4 &c)
 {
-#if __CUDA_ARCH__ >= 600
+#if __CUDA_ARCH__ >= 610 && __CUDACC_VER_MAJOR__ >= 9
     ((int *)&c)[0] = __dp4a(((int *)&a)[0], ((int *)&b)[0], ((int *)&c)[0]);
     ((int *)&c)[1] = __dp4a(((int *)&a)[1], ((int *)&b)[1], ((int *)&c)[1]);
     ((int *)&c)[2] = __dp4a(((int *)&a)[2], ((int *)&b)[2], ((int *)&c)[2]);
@@ -477,7 +477,7 @@ __device__ __inline__ void fma_v4<int8_t>(const int4 a, const int4 b, int4 &c)
 template <>
 __device__ __inline__ void fma_v4<__half>(const int4 a, const int4 b, int4 &c)
 {
-#if __CUDA_ARCH__ >= 600
+#if __CUDA_ARCH__ >= 600 && __CUDACC_VER_MAJOR__ >= 9
     ((__half2 *)&c)[0] = __hfma2(((__half2 *)&a)[0], ((__half2 *)&b)[0], ((__half2 *)&c)[0]);
     ((__half2 *)&c)[1] = __hfma2(((__half2 *)&a)[1], ((__half2 *)&b)[1], ((__half2 *)&c)[1]);
     ((__half2 *)&c)[2] = __hfma2(((__half2 *)&a)[2], ((__half2 *)&b)[2], ((__half2 *)&c)[2]);
@@ -501,7 +501,7 @@ template <>
 __device__ __inline__ int4 add_v4<__half>(const int4 a, const int4 b)
 {
     int4 res = {0, 0, 0, 0};
-#if __CUDA_ARCH__ >= 600
+#if __CUDA_ARCH__ >= 600 && __CUDACC_VER_MAJOR__ >= 9
     ((__half2 *)&res)[0] = __hadd2(((__half2 *)&a)[0], ((__half2 *)&b)[0]);
     ((__half2 *)&res)[1] = __hadd2(((__half2 *)&a)[1], ((__half2 *)&b)[1]);
     ((__half2 *)&res)[2] = __hadd2(((__half2 *)&a)[2], ((__half2 *)&b)[2]);


### PR DESCRIPTION
1. use macro to control host half conversion
2. use macro to control device dp4a&half-related code