### PR TITLE
[fix]: use vector to avoid overflow for pad reshape

### DIFF
--- a/src/ppl/nn/engines/cuda/impls/include/cudakernel/memory/pad.h
+++ b/src/ppl/nn/engines/cuda/impls/include/cudakernel/memory/pad.h
@@ -22,7 +22,6 @@
 #include "ppl/common/retcode.h"
 #include <cuda_runtime.h>
 
-#define PAD_PARAM_MAX_DIM_SIZE 5
 struct PadKernelParam {
     typedef uint32_t pad_mode_t;
     enum { PAD_MODE_CONSTANT = 0,

--- a/src/ppl/nn/oputils/onnx/reshape_pad.cc
+++ b/src/ppl/nn/oputils/onnx/reshape_pad.cc
@@ -30,7 +30,7 @@ RetCode ReshapePad(InputOutputInfo* info, const ir::Attr* arg, const Tpad* start
 
     const TensorShape& shape = *info->GetInput<TensorImpl>(0)->GetShape();
     uint32_t dim_count = shape.GetDimCount();
-    int64_t output_dim[PAD_PARAM_MAX_DIM_SIZE];
+    std::vector<int64_t> output_dim(dim_count, 0);
 
     for (uint32_t it = 0; it < dim_count; ++it) {
         Tpad start_pad = start_pads[it];
@@ -49,7 +49,7 @@ RetCode ReshapePad(InputOutputInfo* info, const ir::Attr* arg, const Tpad* start
         }
         output_dim[it] = cur_dim_size + start_pad + end_pad;
     }
-    info->GetOutput<TensorImpl>(0)->GetShape()->Reshape(output_dim, dim_count);
+    info->GetOutput<TensorImpl>(0)->GetShape()->Reshape(output_dim.data(), dim_count);
 
     return RC_SUCCESS;
 }

--- a/src/ppl/nn/params/onnx/pad_param.h
+++ b/src/ppl/nn/params/onnx/pad_param.h
@@ -24,7 +24,6 @@
 
 namespace ppl { namespace nn { namespace onnx {
 
-#define PAD_PARAM_MAX_DIM_SIZE 5
 
 struct PadParam final : public ir::TypedAttr<PadParam> {
     enum { PAD_MODE_CONSTANT = 0, PAD_MODE_REFLECT = 1, PAD_MODE_EDGE = 2 };


### PR DESCRIPTION
ReshapePad overflow with 6D input