### PR TITLE
[cuda][fix]: possible empty ptx_code under jit mode

### DIFF
--- a/src/ppl/nn/engines/cuda/optimizer/ops/onnx/convtranspose_op.cc
+++ b/src/ppl/nn/engines/cuda/optimizer/ops/onnx/convtranspose_op.cc
@@ -107,7 +107,10 @@ KernelImpl* ConvTransposeOp::CreateKernelImpl() const {
 RetCode ConvTransposeOp::SerializeData(const pmx::SerializationContext& ctx, utils::DataStream* ds) const {
 #ifdef PPLNN_ENABLE_CUDA_JIT
     CUDAModule* module = static_cast<CUDAModule*>(GetCommparamModule());
-    auto ptx_code = module->GetSourceCode().second;
+    std::string ptx_code;
+    if (module) { // for specific algo, may no jit support
+        ptx_code = module->GetSourceCode().second;
+    }
 #else
     std::string ptx_code;
 #endif
@@ -144,12 +147,14 @@ RetCode ConvTransposeOp::DeserializeData(const pmx::DeserializationContext&, con
     }
 
 #ifdef PPLNN_ENABLE_CUDA_JIT
-    CUDAModule* cuda_module = new CUDAModule(); // delete later
-    cuda_module->SetSourceCode(param_.extra_param.algo_info.algo_name, ptx_code);
-    auto cuda_common_param = GetCommparam();
-    if (cuda_common_param->module) delete (CUDAModule*)cuda_common_param->module;
-    cuda_common_param->module = (void*)cuda_module;
-    pmx_module_created_ = true;
+    if (!ptx_code.empty()) { // for depthwise conv, no jit support
+        CUDAModule* cuda_module = new CUDAModule(); // delete later
+        cuda_module->SetSourceCode(param_.extra_param.algo_info.algo_name, ptx_code);
+        auto cuda_common_param = GetCommparam();
+        if (cuda_common_param->module) delete (CUDAModule*)cuda_common_param->module;
+        cuda_common_param->module = (void*)cuda_module;
+        pmx_module_created_ = true;
+    }
 #endif
     return RC_SUCCESS;
 }

--- a/src/ppl/nn/engines/cuda/optimizer/ops/onnx/gemm_op.cc
+++ b/src/ppl/nn/engines/cuda/optimizer/ops/onnx/gemm_op.cc
@@ -128,7 +128,10 @@ KernelImpl* GemmOp::CreateKernelImpl() const {
 RetCode GemmOp::SerializeData(const pmx::SerializationContext& ctx, utils::DataStream* ds) const {
 #ifdef PPLNN_ENABLE_CUDA_JIT
     CUDAModule* module = static_cast<CUDAModule*>(GetCommparamModule());
-    auto ptx_code = module->GetSourceCode().second;
+    std::string ptx_code;
+    if (module) { // for specific algo, may no jit support
+        ptx_code = module->GetSourceCode().second;
+    }
 #else
     std::string ptx_code;
 #endif
@@ -165,12 +168,14 @@ RetCode GemmOp::DeserializeData(const pmx::DeserializationContext&, const void* 
     }
 
 #ifdef PPLNN_ENABLE_CUDA_JIT
-    CUDAModule* cuda_module = new CUDAModule(); // delete later
-    cuda_module->SetSourceCode(param_.extra_param.algo_info.algo_name, ptx_code);
-    auto cuda_common_param = GetCommparam();
-    if (cuda_common_param->module) delete (CUDAModule*)cuda_common_param->module;
-    cuda_common_param->module = (void*)cuda_module;
-    pmx_module_created_ = true;
+    if (!ptx_code.empty()) { // for depthwise conv, no jit support
+        CUDAModule* cuda_module = new CUDAModule(); // delete later
+        cuda_module->SetSourceCode(param_.extra_param.algo_info.algo_name, ptx_code);
+        auto cuda_common_param = GetCommparam();
+        if (cuda_common_param->module) delete (CUDAModule*)cuda_common_param->module;
+        cuda_common_param->module = (void*)cuda_module;
+        pmx_module_created_ = true;
+    }
 #endif
     return RC_SUCCESS;
 }


### PR DESCRIPTION
When encounter depthwise conv or other algos, no jit support, so add a judgement to avoid serialization crash