### PR TITLE
update GetVersionString

### DIFF
--- a/python/package/setup.py
+++ b/python/package/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 from setuptools.dist import Distribution
 
 def GetVersionString():
-    version_file = 'VERSION'
+    version_file = 'VERSION_STRING'
     return open(version_file, 'r').read()
 
 class BinaryDistribution(Distribution):


### PR DESCRIPTION
This PR fix function `GetVersionString`
file `VERSION` has been renamed to `VERSION_STRING`.