### PR TITLE
Cuda mm policy

### DIFF
--- a/src/ppl/nn/engines/cuda/engine.cc
+++ b/src/ppl/nn/engines/cuda/engine.cc
@@ -64,7 +64,7 @@ CudaEngine::~CudaEngine() {
 
 RetCode CudaEngine::Init(const EngineOptions& options) {
     options_ = options;
-    return device_.Init(options.device_id);
+    return device_.Init(options.device_id, options.mm_policy);
 }
 
 EngineContext* CudaEngine::CreateEngineContext() {

--- a/src/ppl/nn/engines/cuda/engine.h
+++ b/src/ppl/nn/engines/cuda/engine.h
@@ -28,7 +28,7 @@
 #include "ppl/nn/engines/cuda/cuda_common_param.h"
 #include "ppl/nn/engines/cuda/engine_context.h"
 #include "ppl/nn/engines/cuda/module/cuda_module.h"
-#include "ppl/nn/engines/cuda/plain_cuda_device.h"
+#include "ppl/nn/engines/cuda/buffered_cuda_device.h"
 #include "ppl/nn/quantization/quant_param_parser.h"
 #include "ppl/nn/models/pmx/serialization_context.h"
 
@@ -99,7 +99,8 @@ private:
 private:
     CudaArgs cuda_flags_;
     EngineOptions options_;
-    PlainCudaDevice device_;
+    // TODO(WJF): if plain cuda device is used, cuda-memcheck would report illegal errors, may bugs within kernels
+    BufferedCudaDevice device_;
     CUDAModuleManager cuda_manager_;
     void* export_algo_arg_ = nullptr;
     void (*export_algo_func_)(const char*, uint64_t, void*) = nullptr;

--- a/src/ppl/nn/engines/cuda/kernels/onnx/conv_depthwise_kernel.cc
+++ b/src/ppl/nn/engines/cuda/kernels/onnx/conv_depthwise_kernel.cc
@@ -84,7 +84,7 @@ ppl::common::RetCode ConvDepthwiseKernel::DoExecute(KernelExecContext* ctx) {
     auto d_weight_scale = ctx->GetInput<TensorImpl>(ctx->GetInputCount() - 1)->GetBufferPtr();
     // auto paddingc = (shape_in1.GetDim(0) + 15) / 16 * 16;
     // cudaMalloc((void**)&d_weight_scale, paddingc*sizeof(float));
-    // cudaMemcpy(d_weight_scale, input_quant1.scale.data(), paddingc*sizeof(float), cudaMemcpyHostToDevice);
+    // cudaMemcpyAsync(d_weight_scale, input_quant1.scale.data(), paddingc*sizeof(float), cudaMemcpyHostToDevice, GetStream());
 
     ConvertToForwardConvParam(shape_in0, shape_in1, shape_out, *param_, temp_conv_param);
     ConvertToForwardFuseParam(ctx, GetCudaDevice(), param_->extra_param.fuse_info, temp_fuse_param);

--- a/src/ppl/nn/engines/cuda/optimizer/algos/algo_conv_imma.cc
+++ b/src/ppl/nn/engines/cuda/optimizer/algos/algo_conv_imma.cc
@@ -275,8 +275,8 @@ RetCode TuringIMMAImpgemm::ModifyParam(ir::Node* node, OptKernelOptions& options
             LOG(ERROR) << node->GetName() << " copy constant failed: " << GetRetCodeStr(status);
             return status;
         }
-        cudaMemcpy(weight_constat_info.GetBufferDesc().addr, temp_buffer.addr,
-                   shape_in1.CalcElementsIncludingPadding() * sizeof(int8_t), cudaMemcpyDeviceToDevice);
+        cudaMemcpyAsync(weight_constat_info.GetBufferDesc().addr, temp_buffer.addr,
+                   shape_in1.CalcElementsIncludingPadding() * sizeof(int8_t), cudaMemcpyDeviceToDevice,  options.device->GetStream());
 
         options.info->constants.emplace(preedge_id, std::move(weight_constat_info));
         *options.tensors->find(preedge_id)->second->GetShape() = newshape;


### PR DESCRIPTION
1. use buffered device in engine to avoid illegal memory access temporarily
2. use async cuda api