### PR TITLE
[fix] fix reshape param default value

### DIFF
--- a/src/ppl/nn/models/onnx/parsers/pmx/parse_reshape_param.cc
+++ b/src/ppl/nn/models/onnx/parsers/pmx/parse_reshape_param.cc
@@ -27,7 +27,7 @@ RetCode ParseReshapeParam(const ::onnx::NodeProto& pb_node, const onnx::ParamPar
                           ir::Attr* arg) {
     auto param = static_cast<onnx::ReshapeParam*>(arg);
 
-    param->allowzero = 1;
+    param->allowzero = 0;
 
     node->SetType({"", "Reshape", 14});
 

--- a/src/ppl/nn/oputils/onnx/reshape_reshape.cc
+++ b/src/ppl/nn/oputils/onnx/reshape_reshape.cc
@@ -46,7 +46,7 @@ RetCode ReshapeReshape(InputOutputInfo* info, const ir::Attr* arg, const int64_t
                 LOG(DEBUG) << "ERROR: axis_need_infer[" << axis_need_infer << "] != -1.";
                 return RC_INVALID_VALUE;
             }
-        } else if (shape_data[i] == 0 && param->allowzero) {
+        } else if (shape_data[i] == 0 && !param->allowzero) {
             if (i < data->GetDimCount()) {
                 reshaped->SetDim(i, data->GetDim(i));
             } else {


### PR DESCRIPTION
By default, [Reshape](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Reshape) param `allowzero` need set to 0.